### PR TITLE
Add Gemini CLI launcher adapter

### DIFF
--- a/lib/adapters/claude.sh
+++ b/lib/adapters/claude.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+adapter_capabilities() { printf '%s\n' 'injection=append headless=yes compaction_hook=yes auto_commit=no'; }
+adapter_headless() { GRANDMA_DISTILLING=1 claude -p "$1" --append-system-prompt "$2"; }
+adapter_launch() {
+  claude --name "$SESSION_NAME" --add-dir "$ROOT" \
+    ${PASSTHRU[@]+"${PASSTHRU[@]}"} --append-system-prompt "$SYSPROMPT" "$INIT"
+}
+adapter_install_compaction_hook() { install_rehydrate_hook "$@"; }
+adapter_cleanup() { :; }

--- a/lib/adapters/gemini.sh
+++ b/lib/adapters/gemini.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+adapter_capabilities() { printf '%s\n' 'injection=contextfile headless=yes compaction_hook=no auto_commit=no'; }
+adapter_headless() { GRANDMA_DISTILLING=1 gemini -p "$2
+
+$1"; }
+adapter_context_file_path() { printf '%s/GEMINI.md' "$PWD"; }
+adapter_cleanup() {
+  [[ "${ADAPTER_CONTEXT_ACTIVE:-0}" == "1" ]] || return 0
+  rm -f "${ADAPTER_CONTEXT_FILE:-}"
+  ADAPTER_CONTEXT_ACTIVE=0
+}
+adapter_launch() {
+  local prompt="$INIT" started rc=0 f m newest="" newest_m=0
+  ADAPTER_CONTEXT_ACTIVE=0
+  ADAPTER_CONTEXT_FILE="$(adapter_context_file_path)"
+  if [[ -e "$ADAPTER_CONTEXT_FILE" ]]; then
+    # Never risk replacing a user's context file. Prepend memory for this session.
+    prompt="$SYSPROMPT
+
+$INIT"
+  else
+    printf '%s\n' "$SYSPROMPT" > "$ADAPTER_CONTEXT_FILE"
+    ADAPTER_CONTEXT_ACTIVE=1
+  fi
+  started="$(date +%s)"
+  gemini --include-directories "$ROOT" -i "$prompt" ${PASSTHRU[@]+"${PASSTHRU[@]}"} || rc=$?
+  # Gemini records newline-delimited JSON under project-specific chats dirs.
+  # Remember only a file touched by this session; save.sh receives it explicitly.
+  for f in "$HOME"/.gemini/tmp/*/chats/session-*.json; do
+    [[ -f "$f" ]] || continue
+    m="$(file_mtime "$f")"
+    [[ "$m" -ge "$started" && "$m" -ge "$newest_m" ]] || continue
+    newest="$f"; newest_m="$m"
+  done
+  # shellcheck disable=SC2034  # consumed by launcher's post-session distiller
+  GRANDMA_LAST_TRANSCRIPT="$newest"
+  return "$rc"
+}

--- a/lib/grandma-launch.sh
+++ b/lib/grandma-launch.sh
@@ -208,8 +208,11 @@ post_session() {
   distilled=1                                    # this session is being handled here; no background pass
 
   printf '\n  🧶 grandma is looking over the session… (Ctrl+C to skip)\n' >&2
-  local proposal=""
-  proposal="$("$ENGINE/lib/grandma-save.sh" "$SCOPE" ${RP_NAME:+"$RP_NAME"} --auto 2>/dev/null | tail -n1)"
+  local proposal="" save_args=("$SCOPE")
+  [[ -n "${RP_NAME:-}" ]] && save_args+=("$RP_NAME")
+  [[ -n "${GRANDMA_LAST_TRANSCRIPT:-}" ]] && save_args+=(--transcript "$GRANDMA_LAST_TRANSCRIPT")
+  save_args+=(--auto)
+  proposal="$("$ENGINE/lib/grandma-save.sh" "${save_args[@]}" 2>/dev/null | tail -n1)"
 
   # Split dirty files: touched during this session vs already dirty at launch. A missing
   # snapshot (abrupt earlier path, mktemp failure) degrades to the old count-everything.
@@ -285,10 +288,14 @@ post_session() {
 background_distill() {
   [ "${distilled:-0}" = 1 ] && return
   distilled=1
-  nohup "$ENGINE/lib/grandma-save.sh" "$SCOPE" ${RP_NAME:+"$RP_NAME"} --auto >/dev/null 2>&1 &
+  local save_args=("$SCOPE")
+  [[ -n "${RP_NAME:-}" ]] && save_args+=("$RP_NAME")
+  [[ -n "${GRANDMA_LAST_TRANSCRIPT:-}" ]] && save_args+=(--transcript "$GRANDMA_LAST_TRANSCRIPT")
+  save_args+=(--auto)
+  nohup "$ENGINE/lib/grandma-save.sh" "${save_args[@]}" >/dev/null 2>&1 &
   disown 2>/dev/null || true
 }
-on_hangup() { rm -f "${PRE_DIRTY_SNAP:-}" 2>/dev/null; background_distill; exit 129; }
+on_hangup() { rm -f "${PRE_DIRTY_SNAP:-}" 2>/dev/null; adapter_cleanup 2>/dev/null || true; background_distill; exit 129; }
 
 # ---- parse args: grandma <sweater> [project] [task...] [--full] [--writing] ----
 # A single bare word right after the scope (no spaces, before any task words) is the project.
@@ -339,6 +346,8 @@ if ! resolve_scope_dir "$SCOPE" >/dev/null 2>&1; then
     exit 1
   fi
 fi
+
+grandma_load_adapter "$SCOPE"
 
 # Assemble the scope bundle (global + scope memory). Same for all paths below.
 BUNDLE="$("$ASSEMBLE" "$SCOPE" ${PASS[@]+"${PASS[@]}"})"
@@ -427,6 +436,9 @@ if [[ "${GRANDMA_DRY_RUN:-0}" == "1" ]]; then
     if [[ "${GRANDMA_NO_HOOK:-0}" == "1" ]]; then
       echo "rehydrate:    skipped (GRANDMA_NO_HOOK=1)" >&2
       echo "autosave:     skipped (GRANDMA_NO_HOOK=1)" >&2
+    elif ! command -v adapter_install_compaction_hook >/dev/null 2>&1; then
+      echo "rehydrate:    unavailable ($GRANDMA_CLI_SELECTED has no compaction hook)" >&2
+      echo "autosave:     wrapped session distills after exit" >&2
     else
       echo "rehydrate:    would ensure SessionStart(compact) hook in $LAUNCH_DIR/.claude/settings.local.json" >&2
       if [[ "${GRANDMA_NO_AUTOSAVE:-0}" == "1" ]]; then
@@ -436,14 +448,15 @@ if [[ "${GRANDMA_DRY_RUN:-0}" == "1" ]]; then
       fi
     fi
   fi
-  [[ ${#PASSTHRU[@]} -gt 0 ]] && echo "passthru:     ${PASSTHRU[*]} (forwarded to claude)" >&2
+  echo "adapter:      $GRANDMA_CLI_SELECTED ($(adapter_capabilities))" >&2
+  [[ ${#PASSTHRU[@]} -gt 0 ]] && echo "passthru:     ${PASSTHRU[*]} (forwarded to $GRANDMA_CLI_SELECTED)" >&2
   if compgen -G "$ROOT/proposals/${SCOPE}*.md" >/dev/null 2>&1; then
     pn="$(ls -1 "$ROOT/proposals/${SCOPE}"*.md 2>/dev/null | wc -l | tr -d ' ')"
     echo "review:       $pn pending proposal(s) — accepting the offer execs: grandma review --apply $SCOPE" >&2
   fi
   echo "capture:      doctrine loaded (prompts/capture.md) · grandma repo writable via --add-dir" >&2
   echo "banner:       $BANNER" >&2
-  echo "would launch: (cd ${LAUNCH_DIR:-.} && claude --name grandma:$SCOPE${RP_NAME:+/$RP_NAME} ${PASSTHRU[*]:-} --append-system-prompt <bundle> <init>)" >&2
+  echo "would launch: (cd ${LAUNCH_DIR:-.} && $GRANDMA_CLI_SELECTED adapter launches grandma:$SCOPE${RP_NAME:+/$RP_NAME} with <bundle> <init>)" >&2
   echo "--- init prompt ---" >&2
   printf '%s\n' "$INIT" >&2
   echo "--- sysprompt: ${#SYSPROMPT} chars ---" >&2
@@ -452,8 +465,8 @@ fi
 
 # For a known project, ensure the compaction-rehydrate + auto-distill hooks are installed.
 if [[ -n "$LAUNCH_DIR" ]]; then
-  install_rehydrate_hook "$LAUNCH_DIR" "$SCOPE"
-  install_session_end_hook "$LAUNCH_DIR" "$SCOPE" "$RP_NAME"
+  command -v adapter_install_compaction_hook >/dev/null 2>&1 && adapter_install_compaction_hook "$LAUNCH_DIR" "$SCOPE"
+  [[ "$GRANDMA_CLI_SELECTED" == "claude" ]] && install_session_end_hook "$LAUNCH_DIR" "$SCOPE" "$RP_NAME"
   [[ "${GRANDMA_HOOK_INSTALLED:-0}" == "1" || "${GRANDMA_AUTOSAVE_INSTALLED:-0}" == "1" ]] && \
     printf '  + installed grandma hooks (%s/.claude/settings.local.json)\n' "$RP_NAME" >&2
 fi
@@ -520,8 +533,11 @@ distilled=0
 # Abrupt exit (window closed / terminated): capture the session in the background so it is
 # never lost. Clean exit: disarm, then post_session distills + reviews in the foreground.
 trap on_hangup HUP TERM
+# shellcheck disable=SC2034  # consumed by the sourced adapter function
+SESSION_NAME="grandma:$SCOPE${RP_NAME:+/$RP_NAME}"
 CLAUDE_RC=0
-claude --name "grandma:$SCOPE${RP_NAME:+/$RP_NAME}" --add-dir "$ROOT" ${PASSTHRU[@]+"${PASSTHRU[@]}"} --append-system-prompt "$SYSPROMPT" "$INIT" || CLAUDE_RC=$?
+adapter_launch || CLAUDE_RC=$?
 trap - HUP TERM
+adapter_cleanup
 post_session
 exit "$CLAUDE_RC"

--- a/lib/grandma-lib.sh
+++ b/lib/grandma-lib.sh
@@ -76,3 +76,45 @@ notify_user() {
   osascript -e "display notification \"$2\" with title \"$1\" sound name \"Glass\"" 2>/dev/null \
     || notify-send "$1" "$2" 2>/dev/null || true
 }
+
+# Select a model CLI adapter: environment, sweater frontmatter, home config, default.
+grandma_select_cli() { # optional sweater name
+  local sweater="${1:-}" selected="${GRANDMA_CLI:-}" dir="" file="" value=""
+  if [[ -z "$selected" && -n "$sweater" ]]; then
+    dir="$(resolve_scope_dir "$sweater" 2>/dev/null || true)"
+    if [[ -n "$dir" ]]; then
+      for file in "$dir"/*.md; do
+        [[ -f "$file" ]] || continue
+        value="$(awk 'NR==1 && $0=="---" {f=1; next} f && $0=="---" {exit}
+          f && /^[[:space:]]*cli:[[:space:]]*/ {sub(/^[[:space:]]*cli:[[:space:]]*/,"");
+          gsub(/[[:space:]]+$/,""); print; exit}' "$file")"
+        [[ -n "$value" ]] && { selected="$value"; break; }
+      done
+    fi
+  fi
+  if [[ -z "$selected" ]]; then
+    for file in "$ROOT/config" "$ROOT/config.md"; do
+      [[ -f "$file" ]] || continue
+      value="$(sed -n 's/^[[:space:]]*cli:[[:space:]]*\([^#[:space:]]*\).*/\1/p' "$file" | head -n1)"
+      [[ -n "$value" ]] && { selected="$value"; break; }
+    done
+  fi
+  selected="$(printf '%s' "${selected:-claude}" | tr '[:upper:]' '[:lower:]')"
+  case "$selected" in (*[!a-z0-9_-]*|'') echo "invalid grandma CLI adapter: $selected" >&2; return 2 ;; esac
+  printf '%s' "$selected"
+}
+
+grandma_load_adapter() { # optional sweater name
+  GRANDMA_CLI_SELECTED="$(grandma_select_cli "${1:-}")" || return
+  GRANDMA_ADAPTER="$ENGINE/lib/adapters/$GRANDMA_CLI_SELECTED.sh"
+  [[ -r "$GRANDMA_ADAPTER" ]] || {
+    echo "unknown grandma CLI adapter '$GRANDMA_CLI_SELECTED'" >&2; return 2;
+  }
+  # shellcheck source=/dev/null
+  source "$GRANDMA_ADAPTER"
+  command -v adapter_capabilities >/dev/null 2>&1 \
+    && command -v adapter_headless >/dev/null 2>&1 \
+    && command -v adapter_launch >/dev/null 2>&1 || {
+      echo "adapter '$GRANDMA_CLI_SELECTED' is missing a required function" >&2; return 2;
+    }
+}

--- a/lib/grandma-save.sh
+++ b/lib/grandma-save.sh
@@ -53,6 +53,7 @@ if [[ -z "$SCOPE" ]]; then
   echo "usage: grandma-save <sweater> [project] [--transcript <path>] [--auto]" >&2
   exit 2
 fi
+grandma_load_adapter "$SCOPE"
 
 # ---- resolve project (optional) ----
 SCOPE_DIR=""
@@ -90,11 +91,12 @@ fi
 # to that dir, so a /var/folders temp file would be unreadable. Prune stale ones first.
 mkdir -p "$ROOT/.distill"
 find "$ROOT/.distill" -name '*.md' -mmin +120 -delete 2>/dev/null || true
-readable="$ROOT/.distill/$(basename "$TRANSCRIPT" .jsonl).md"
+transcript_name="$(basename "$TRANSCRIPT")"
+readable="$ROOT/.distill/${transcript_name%.*}.md"
 jq -r '
-  select(.type=="user" or .type=="assistant")
-  | (.message.role // .type) as $role
-  | (.message.content) as $c
+  select(.type=="user" or .type=="assistant" or .type=="gemini")
+  | (if .type=="gemini" then "assistant" else (.message.role // .type) end) as $role
+  | (if .message then .message.content else .content end) as $c
   | if ($c|type)=="string" then "\($role|ascii_upcase): \($c)\n"
     else ($c | map(select(.type=="text") | .text) | join("\n")) as $t
          | if ($t|length)>0 then "\($role|ascii_upcase): \($t)\n" else empty end
@@ -131,7 +133,7 @@ if [[ "$AUTO" == "1" ]]; then
     echo "grandma auto-distill CIRCUIT BREAKER: $recent proposals in the last 5 min (cap $CAP). Refusing (likely runaway)." >&2
     exit 0
   fi
-  stamp="$(basename "$TRANSCRIPT" .jsonl)"
+  stamp="${transcript_name%.*}"
   out="$ROOT/proposals/${SCOPE}${PROJECT_NAME:+-$PROJECT_NAME}-${stamp}.md"
   ASYS="$(cat "$DISTILLER")
 
@@ -159,7 +161,7 @@ one-line why. If nothing is durable, output exactly 'No durable learnings.'"
   { echo "# grandma memory proposal"
     echo "# scope=$SCOPE${PROJECT_NAME:+ project=$PROJECT_NAME}  transcript=$(basename "$TRANSCRIPT")"
     echo
-    ( cd "$ROOT" && GRANDMA_DISTILLING=1 claude -p "$APROMPT" --append-system-prompt "$ASYS" 2>/dev/null ) || echo "(distiller failed)"
+    ( cd "$ROOT" && adapter_headless "$APROMPT" "$ASYS" 2>/dev/null ) || echo "(distiller failed)"
   } > "$out"
   rm -f "$readable"
   # Keep the proposal only if the distiller actually proposed something. A "No durable

--- a/lib/grandma-test.sh
+++ b/lib/grandma-test.sh
@@ -21,6 +21,9 @@ CORE=(lib/grandma-launch.sh lib/grandma-lib.sh lib/grandma-rehydrate.sh lib/gran
       lib/grandma-save.sh lib/grandma-ingest.sh lib/grandma-review.sh lib/assemble.sh \
       prompts/distiller.md prompts/onboard.md prompts/ingest.md prompts/new-scope.md \
       prompts/capture.md lib/grandma-watch.sh prompts/watch-digest.md prompts/watch-report.md)
+for adapter in "$ENGINE"/lib/adapters/*.sh; do
+  [[ -f "$adapter" ]] && CORE+=("lib/adapters/$(basename "$adapter")")
+done
 
 fail=0
 pass() { printf '  \033[32mok\033[0m   %s\n' "$1"; }
@@ -127,7 +130,7 @@ rg_ok=1
 # The SessionEnd hook must bail when GRANDMA_DISTILLING is set, and must set it when spawning.
 grep -q 'GRANDMA_DISTILLING.*==.*1.*exit 0\|GRANDMA_DISTILLING:-0.*==.*1' "$ENGINE/lib/grandma-session-end.sh" 2>/dev/null || { bad "grandma-session-end.sh missing GRANDMA_DISTILLING guard (recursion risk)"; rg_ok=0; }
 grep -q 'GRANDMA_DISTILLING=1' "$ENGINE/lib/grandma-session-end.sh" 2>/dev/null || { bad "grandma-session-end.sh does not set GRANDMA_DISTILLING when spawning the distill"; rg_ok=0; }
-grep -q 'GRANDMA_DISTILLING=1 claude -p' "$ENGINE/lib/grandma-save.sh" 2>/dev/null || { bad "grandma-save.sh --auto does not guard its claude -p with GRANDMA_DISTILLING"; rg_ok=0; }
+grep -q 'adapter_headless' "$ENGINE/lib/grandma-save.sh" 2>/dev/null || { bad "grandma-save.sh --auto does not use the guarded adapter headless path"; rg_ok=0; }
 [[ "$rg_ok" == "1" ]] && pass "auto-distill recursion guard in place"
 
 # ---- 8. Auto-distill circuit breaker present (airbag: bounds any runaway) ----
@@ -154,7 +157,10 @@ grep -q 'seven categories' "$ENGINE/prompts/capture.md" 2>/dev/null || { bad "ca
 grep -q 'prompts/capture.md' "$ENGINE/lib/grandma-launch.sh" 2>/dev/null || { bad "launch does not inject capture.md"; cap_ok=0; }
 grep -q 'prompts/capture.md' "$ENGINE/lib/grandma-rehydrate.sh" 2>/dev/null || { bad "grandma-rehydrate.sh does not re-inject capture.md after compaction"; cap_ok=0; }
 grep -q 'prompts/capture.md' "$ENGINE/lib/grandma-save.sh" 2>/dev/null || { bad "grandma-save.sh sweep does not load capture.md"; cap_ok=0; }
-grep -q -- '--add-dir "\$ROOT"' "$ENGINE/lib/grandma-launch.sh" 2>/dev/null || { bad "launch missing --add-dir for the memory repo (captures can't write)"; cap_ok=0; }
+if ! grep -q -- '--add-dir "\$ROOT"' "$ENGINE/lib/adapters/claude.sh" 2>/dev/null \
+   || ! grep -q -- '--include-directories "\$ROOT"' "$ENGINE/lib/adapters/gemini.sh" 2>/dev/null; then
+  bad "adapters do not grant the model access to the memory repo (captures can't write)"; cap_ok=0
+fi
 [[ "$cap_ok" == "1" ]] && pass "capture doctrine present and wired (launch + rehydrate + sweep + writable repo)"
 
 # ---- 11. Watch machinery is guarded (no runaway LLM, no leaks) ----

--- a/lib/grandma-watch.sh
+++ b/lib/grandma-watch.sh
@@ -27,18 +27,13 @@ set -uo pipefail
 ENGINE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT="${GRANDMA_HOME:-$HOME/.grandma}"   # the user's private memory home
 source "$ENGINE/lib/grandma-lib.sh"
+grandma_load_adapter ""
 WATCHES="$ROOT/watches"
 CLAUDE_PROJECTS="$HOME/.claude/projects"
 DIGEST_CAP="${GRANDMA_WATCH_DIGEST_CAP:-12}"     # max sessions digested per tick (cost bound)
 QUIET_MIN=30                                      # only digest sessions idle >= this many minutes
 
-claude_bin() {
-  command -v claude 2>/dev/null && return 0
-  for c in "$HOME/.local/bin/claude" "$HOME/.claude/local/claude" /opt/homebrew/bin/claude /usr/local/bin/claude; do
-    [[ -x "$c" ]] && { echo "$c"; return 0; }
-  done
-  return 1
-}
+adapter_bin() { command -v "$GRANDMA_CLI_SELECTED" 2>/dev/null; }
 
 slugify() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | cut -c1-40 | sed 's/^-//; s/-$//'; }
 
@@ -194,7 +189,7 @@ print(f"metrics: {len(old)} sessions")
 PY
 
   # ---- 2. LLM micro-digests: new, quiet sessions, capped per tick ----
-  local CB; CB="$(claude_bin || true)"
+  local CB; CB="$(adapter_bin || true)"
   if [[ -n "$CB" ]]; then
     touch "$dir/data/digests.done"
     : > "$dir/.work/batch.md"
@@ -240,11 +235,11 @@ PY
       SYS="$(cat "$ENGINE/prompts/watch-digest.md")
 
 STUDY QUESTION: $question"
-      OUT="$( cd "$ROOT" && GRANDMA_DISTILLING=1 "$CB" -p \
+      OUT="$( cd "$ROOT" && adapter_headless \
         "Digest each session below per your instructions, focused on the watch question.
 
 $(cat "$dir/.work/batch.md")" \
-        --append-system-prompt "$SYS" 2>/dev/null )" || OUT=""
+        "$SYS" 2>/dev/null )" || OUT=""
       if [[ -n "$OUT" ]]; then
         { echo; echo "----- tick $(date '+%Y-%m-%d %H:%M') -----"; printf '%s\n' "$OUT"; } >> "$dir/data/digests.md"
         cat "$dir/.work/batch.ids" >> "$dir/data/digests.done"
@@ -280,7 +275,7 @@ PY
     RSYS="$(cat "$ENGINE/prompts/watch-report.md")
 
 STUDY QUESTION: $question"
-    ( cd "$ROOT" && GRANDMA_DISTILLING=1 "$CB" -p \
+    ( cd "$ROOT" && adapter_headless \
       "Write the final watch report per your instructions.
 
 ===== METRICS =====
@@ -288,7 +283,7 @@ $(cat "$dir/.work/metrics-summary.md")
 
 ===== SESSION DIGESTS =====
 $(cat "$dir/data/digests.md" 2>/dev/null || echo '(no digests collected)')" \
-      --append-system-prompt "$RSYS" 2>/dev/null ) > "$dir/report.md" || true
+      "$RSYS" 2>/dev/null ) > "$dir/report.md" || true
     if [[ -s "$dir/report.md" ]]; then
       set_field "$sj" status '"complete"'
       notify_user "grandma watch" "Report ready: $(basename "$dir")"

--- a/test/cmd_gemini.sh
+++ b/test/cmd_gemini.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Behavioral coverage for the hookless Gemini adapter and its cleanup boundary.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE="$(cd "$HERE/.." && pwd)"
+. "$HERE/lib/assert.sh"
+. "$HERE/lib/fixture.sh"
+
+GBIN="$ENGINE/bin/grandma"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+export GRANDMA_HOME="$TMP/home" HOME="$TMP/fakehome" SHELL="" GRANDMA_NO_SPLASH=1
+make_fixture_home "$GRANDMA_HOME"
+
+SHIM="$TMP/bin"; mkdir -p "$SHIM"
+cat > "$SHIM/gemini" <<'SHIM'
+#!/usr/bin/env bash
+mkdir -p "$HOME/.gemini/tmp/fake-project/chats"
+printf '%s\n' '{"id":"u1","timestamp":"2026-07-17T00:00:00Z","type":"user","content":[{"text":"remember this"}]}' > "$HOME/.gemini/tmp/fake-project/chats/session-test.json"
+printf '%s\n' '{"id":"a1","timestamp":"2026-07-17T00:00:01Z","type":"gemini","content":[{"text":"understood"}]}' >> "$HOME/.gemini/tmp/fake-project/chats/session-test.json"
+printf 'distilling=%s\n' "${GRANDMA_DISTILLING:-unset}"
+exit 0
+SHIM
+chmod +x "$SHIM/gemini"
+
+section "gemini — dry-run and hookless degradation"
+capture env PATH="$SHIM:$PATH" GRANDMA_CLI=gemini GRANDMA_DRY_RUN=1 "$GBIN" home-ops yard
+assert_rc 0 "Gemini dry-run survives set -u with kebab sweater"
+assert_contains "adapter:      gemini" "selects the Gemini adapter"
+assert_contains "injection=contextfile" "reports native context-file injection"
+assert_contains "rehydrate:    unavailable" "degrades honestly without a compaction hook"
+assert_contains "KNOWN project 'Yard'" "resolves the kebab fixture project"
+
+section "gemini — config and environment precedence"
+printf 'cli: gemini\n' > "$GRANDMA_HOME/config"
+capture env PATH="$SHIM:$PATH" GRANDMA_DRY_RUN=1 "$GBIN" globex
+assert_contains "adapter:      gemini" "home config selects Gemini"
+capture env PATH="$SHIM:$PATH" GRANDMA_CLI=claude GRANDMA_DRY_RUN=1 "$GBIN" globex
+assert_contains "adapter:      claude" "environment overrides home config"
+{ head -n4 "$GRANDMA_HOME/home-ops/facts.md"; echo 'cli: gemini'; tail -n +5 "$GRANDMA_HOME/home-ops/facts.md"; } > "$TMP/facts.md"
+mv "$TMP/facts.md" "$GRANDMA_HOME/home-ops/facts.md"
+printf 'cli: claude\n' > "$GRANDMA_HOME/config"
+capture env PATH="$SHIM:$PATH" GRANDMA_DRY_RUN=1 "$GBIN" home-ops
+assert_contains "adapter:      gemini" "sweater frontmatter overrides home config"
+capture env PATH="$SHIM:$PATH" GRANDMA_CLI=claude GRANDMA_DRY_RUN=1 "$GBIN" home-ops
+assert_contains "adapter:      claude" "environment overrides sweater frontmatter"
+capture env PATH="$SHIM:$PATH" GRANDMA_CLI='../bad' GRANDMA_DRY_RUN=1 "$GBIN" globex
+assert_rc 2 "rejects a traversal-shaped adapter name"
+
+section "gemini — temporary context cleanup"
+project="$GRANDMA_HOME/projects/yard"
+rm -f "$project/GEMINI.md"
+capture env PATH="$SHIM:$PATH" GRANDMA_CLI=gemini GRANDMA_NO_AUTOSAVE=1 "$GBIN" home-ops yard </dev/null
+assert_rc 0 "wrapped Gemini session returns its status"
+assert_no_file "$project/GEMINI.md" "removes the temporary memory-bearing context file"
+
+printf '# user-owned Gemini context\n' > "$project/GEMINI.md"
+before="$(cksum < "$project/GEMINI.md")"
+capture env PATH="$SHIM:$PATH" GRANDMA_CLI=gemini GRANDMA_NO_AUTOSAVE=1 "$GBIN" home-ops yard </dev/null
+assert_rc 0 "Gemini runs when a user context file already exists"
+after="$(cksum < "$project/GEMINI.md")"
+if [[ "$before" == "$after" ]]; then ok "preserves an existing GEMINI.md byte-for-byte"
+else fail "changed a user-owned GEMINI.md"; fi
+
+section "gemini — guarded headless adapter"
+capture env PATH="$SHIM:$PATH" GRANDMA_CLI=gemini bash -c 'ENGINE="$1"; ROOT="$2"; source "$ENGINE/lib/grandma-lib.sh"; grandma_load_adapter ""; adapter_headless prompt system' _ "$ENGINE" "$GRANDMA_HOME"
+assert_rc 0 "Gemini headless adapter runs"
+assert_contains "distilling=1" "headless calls inherit the recursion guard"
+
+section "gemini — transcript reaches the existing distiller"
+transcript="$HOME/.gemini/tmp/fake-project/chats/session-test.json"
+capture env PATH="$SHIM:$PATH" GRANDMA_CLI=gemini "$ENGINE/lib/grandma-save.sh" home-ops --transcript "$transcript" --auto
+assert_rc 0 "Gemini JSONL transcript can be distilled"
+proposal="$(find "$GRANDMA_HOME/proposals" -name 'home-ops-session-test.md' -print | head -n1)"
+assert_file "$proposal" "writes a proposal from the Gemini session transcript"
+
+echo
+if [ "$FAILS" -eq 0 ]; then echo "cmd_gemini: PASS"; else echo "cmd_gemini: $FAILS FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
Closes #22.

This adds the adapter seam and a Gemini implementation while preserving Claude as the default:

- selects `GRANDMA_CLI`, then sweater frontmatter, then `$GRANDMA_HOME/config`, then Claude
- routes launch, headless save, and watch model calls through required adapter functions
- injects Gemini memory through a temporary `GEMINI.md`, or prepends it when a user-owned file already exists
- wraps hookless Gemini sessions, cleans temporary context on exit/signal, and never installs Claude hooks
- locates Gemini automatic session JSONL and passes it into the existing guarded distiller
- adds kebab-sweater, precedence, cleanup, transcript, and recursion-guard regression coverage

Verification:

- `./test/run.sh` — all suites pass on Linux
- `shellcheck -S warning bin/grandma lib/*.sh lib/adapters/*.sh install.sh test/*.sh test/lib/*.sh` — clean
- `git diff --check` — clean

The adapter uses documented `gemini -i` interactive and `gemini -p` headless modes. It does not use `GEMINI_SYSTEM_MD`, so Gemini keeps its native coding system prompt. Existing `GEMINI.md` content is left byte-for-byte unchanged.