### PR TITLE
Show the mascot in every terminal: GIF where supported, animated wordmark elsewhere

### DIFF
--- a/lib/grandma-init.sh
+++ b/lib/grandma-init.sh
@@ -9,6 +9,8 @@
 set -uo pipefail
 ENGINE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT="${GRANDMA_HOME:-$HOME/.grandma}"
+# For grandma_splash / pick_mascot_renderer, so the interview shows the same mascot as a session.
+source "$ENGINE/lib/grandma-lib.sh"
 
 ok()   { printf '  \033[32mok\033[0m   %s\n' "$1"; }
 warn() { printf '  \033[33mwarn\033[0m %s\n' "$1"; }
@@ -37,7 +39,13 @@ cmd_doctor() {
   fi
 
   echo "== nice to have =="
-  command -v imgcat >/dev/null 2>&1 && ok "imgcat (animated mascot splash)" || warn "no imgcat — splash falls back to ASCII granny (iTerm2 users: install imgcat)"
+  local mren; mren="$(pick_mascot_renderer)"
+  if terminal_supports_graphics; then
+    [[ -n "$mren" ]] && ok "mascot: GIF via $mren (graphics terminal)" \
+                     || warn "graphics terminal but no renderer — 'brew install chafa' for the GIF mascot"
+  else
+    ok "mascot: wordmark logo (this terminal has no image protocol)"
+  fi
   case ":$PATH:" in *":$ENGINE/bin:"*) ok "grandma on PATH" ;; *) warn "engine bin not on PATH — add: export PATH=\"$ENGINE/bin:\$PATH\"" ;; esac
 
   [[ "$bad" == "0" ]] && echo "doctor: healthy" || { echo "doctor: fix the items above"; return 1; }
@@ -95,6 +103,7 @@ cmd_init() {
     if [[ "${a:-y}" =~ ^[Yy]?$ ]]; then
       local SYS; SYS="$(cat "$ENGINE/prompts/init-interview.md")"
       cd "$ROOT" || exit 1
+      grandma_splash "grandma"
       exec claude --name "grandma:init" --append-system-prompt "$SYS" \
         "Introduce yourself, explain what a sweater is, interview me, and fill in my identity and preferences per your instructions."
     fi

--- a/lib/grandma-launch.sh
+++ b/lib/grandma-launch.sh
@@ -25,33 +25,8 @@ ENGINE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT="${GRANDMA_HOME:-$HOME/.grandma}"   # the user's private memory home
 ASSEMBLE="$ENGINE/lib/assemble.sh"
 
-# grandma_splash — the "grandma pops up" moment before the session loads.
-# Plays assets/grandma.gif via imgcat (iTerm2) if present, else prints ASCII granny.
-# Skip with GRANDMA_NO_SPLASH=1; tune the pause with GRANDMA_SPLASH_SECS.
-grandma_splash() {
-  [[ "${GRANDMA_NO_SPLASH:-0}" == "1" ]] && return 0
-  local scope="$1" gif="$ENGINE/assets/grandma.gif"
-  local P=$'\033[95m' B=$'\033[1m' D=$'\033[2m' R=$'\033[0m'
-  printf '\n'
-  if [[ -f "$gif" ]] && command -v imgcat >/dev/null 2>&1; then
-    imgcat --height "${GRANDMA_SPLASH_HEIGHT:-14}" "$gif" 2>/dev/null || true
-  else
-    printf '%s' "$P"
-    printf '%s\n' "        .-\"\"\"\"\"-."
-    printf '%s\n' "       / .---. \\"
-    printf '%s\n' "      / /     \\ \\"
-    printf '%s\n' "      | | o o | |"
-    printf '%s\n' "     _|  \\ ^ /  |_"
-    printf '%s\n' "    / |   '-'   | \\"
-    printf '%s\n' "      |         |"
-    printf '%s%s' "$R" ""
-  fi
-  printf '  %s%sGRANDMA%s  %sshe remembers everything%s\n' "$B" "$P" "$R" "$D" "$R"
-  printf '  %sfetching %s memory...%s\n\n' "$D" "$scope" "$R"
-  sleep "${GRANDMA_SPLASH_SECS:-0.7}"
-}
-
 # ---- helpers ----
+# grandma_splash lives in grandma-lib.sh so launch and init share one mascot implementation.
 source "$ENGINE/lib/grandma-lib.sh"
 
 # Launch the new-sweater creator: read a free-text description, hand it to an LLM session
@@ -365,10 +340,11 @@ fi
 
 # Dry run: show what would launch, don't start Claude.
 if [[ "${GRANDMA_DRY_RUN:-0}" == "1" ]]; then
-  if [[ -f "$ENGINE/assets/grandma.gif" ]] && command -v imgcat >/dev/null 2>&1; then
-    echo "splash:       gif (assets/grandma.gif via imgcat)" >&2
+  splash_renderer="$(pick_mascot_renderer)"
+  if [[ -f "$ENGINE/assets/grandma.gif" && -n "$splash_renderer" ]]; then
+    echo "splash:       gif (assets/grandma.gif via $splash_renderer)" >&2
   else
-    echo "splash:       ascii granny (drop assets/grandma.gif for the gif)" >&2
+    echo "splash:       wordmark logo (this terminal has no image protocol)" >&2
   fi
   if [[ -n "$LAUNCH_DIR" ]]; then
     echo "mode:         KNOWN project '$RP_NAME' → cd $LAUNCH_DIR (its CLAUDE.md auto-loads)" >&2

--- a/lib/grandma-lib.sh
+++ b/lib/grandma-lib.sh
@@ -16,6 +16,118 @@ resolve_scope_dir() {
 # Normalize a name for fuzzy matching: lowercase, alphanumeric only.
 norm() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]'; }
 
+# Does this terminal have a real inline-image protocol? Only these can render the GIF crisply.
+# Everywhere else (Apple Terminal, most VS Code, plain xterm) an image degrades to colored
+# blocks that read as a broken picture — so grandma draws crafted ANSI art there instead.
+terminal_supports_graphics() {
+  case "${TERM_PROGRAM:-}" in iTerm.app|WezTerm) return 0 ;; esac
+  case "${TERM:-}" in *kitty*|*sixel*) return 0 ;; esac
+  [[ -n "${KITTY_WINDOW_ID:-}" ]] && return 0
+  return 1
+}
+
+# Pick a renderer for the mascot GIF, but ONLY on a graphics-capable terminal. imgcat is
+# iTerm2-native; chafa auto-detects kitty/sixel/iTerm2 graphics. Echo the tool, or nothing —
+# nothing means "no crisp GIF here, use the typographic wordmark instead."
+pick_mascot_renderer() {
+  terminal_supports_graphics || return 0
+  if [[ "${TERM_PROGRAM:-}" == "iTerm.app" ]] && command -v imgcat >/dev/null 2>&1; then
+    echo imgcat
+  elif command -v chafa >/dev/null 2>&1; then
+    echo chafa
+  fi
+}
+
+# _grandma_word_frame — one frame of the wordmark: needle tip, six gradient letter rows with a
+# standing knitting needle (shaft + pink yarn stitches), and the needle knob. Pre-rendered
+# "grandma" (figlet slant), so no figlet dependency. $1 = glint column (-1 = static, no shimmer).
+_grandma_word_frame() {
+  local c="$1" R=$'\033[0m' TAN=$'\033[38;5;180m' WOOD=$'\033[38;5;137m' STITCH=$'\033[38;5;211m'
+  local PAD=48 HL=231 i base l x ch col
+  local WL=(
+    '                               __               '
+    '   ____ __________ _____  ____/ /___ ___  ____ _'
+    '  / __ `/ ___/ __ `/ __ \/ __  / __ `__ \/ __ `/'
+    ' / /_/ / /  / /_/ / / / / /_/ / / / / / / /_/ / '
+    ' \__, /_/   \__,_/_/ /_/\__,_/_/ /_/ /_/\__,_/  '
+    '/____/                                          '
+  )
+  local G=(218 212 206 205 169 168)   # light pink -> deep magenta, per row
+  printf '%*s%s▴%s\n' "$((PAD+1))" '' "$TAN" "$R"          # needle tip, above the word
+  for i in 0 1 2 3 4 5; do
+    base=${G[$i]}; l=${WL[$i]}
+    while [ ${#l} -lt "$PAD" ]; do l="$l "; done
+    if [ "$c" -lt 0 ]; then
+      printf '\033[38;5;%sm%s%s' "$base" "$l" "$R"          # whole row, one color (static)
+    else
+      x=0                                                    # per-character, with a moving glint
+      while [ "$x" -lt ${#l} ]; do
+        ch=${l:$x:1}
+        if [ "$(( x>=c ? x-c : c-x ))" -le 2 ]; then col=$HL; else col=$base; fi
+        printf '\033[38;5;%sm%s' "$col" "$ch"; x=$((x+1))
+      done
+      printf '%s' "$R"
+    fi
+    # standing needle beside the row — glyphs are literals in the format (multibyte-safe)
+    if [ "$i" -le 2 ]; then printf ' %s┃%s %s◦%s\n' "$TAN" "$R" "$STITCH" "$R"
+    else printf ' %s┃%s\n' "$TAN" "$R"; fi
+  done
+  printf '%*s%s◖●◗%s\n' "$PAD" '' "$WOOD" "$R"             # needle knob, below the word
+}
+
+# _grandma_yarn — the knitted yarn thread + tagline. $1 = thread length (0..14).
+_grandma_yarn() {
+  local n="$1" R=$'\033[0m' D=$'\033[2m' GREY=$'\033[38;5;247m'
+  local MAG=$'\033[38;5;205m' BALL=$'\033[38;5;213m' t='' i=0
+  while [ "$i" -lt "$n" ]; do t="$t~"; i=$((i+1)); done
+  printf '   %s●%s%s%s   %s%sshe remembers everything%s\n' "$BALL" "$MAG" "$t" "$R" "$D" "$GREY" "$R"
+}
+
+# grandma_wordmark — a sharp typographic "grandma" logo for terminals with no image protocol
+# (Apple Terminal, VS Code, plain xterm), where a raster image only renders as blurry blocks.
+# On a wide TTY it plays a light shimmer + a knitting yarn once; otherwise it draws static.
+grandma_wordmark() {
+  local FULL=14 PAD=48 step=0 c yl cols
+  cols=$(tput cols 2>/dev/null); [ -n "$cols" ] || cols=80
+  if [ -t 1 ] && [ "${GRANDMA_SPLASH_STATIC:-0}" != "1" ] && [ "$cols" -ge 54 ]; then
+    _grandma_word_frame -1; _grandma_yarn 0
+    for c in $(seq -3 3 $((PAD+3))); do
+      printf '\033[9A'                              # up over 8 word rows + 1 yarn row
+      _grandma_word_frame "$c"
+      yl=$(( step * FULL / ((PAD+6)/3) )); [ "$yl" -gt "$FULL" ] && yl=$FULL
+      _grandma_yarn "$yl"
+      step=$((step+1)); sleep 0.025
+    done
+    printf '\033[9A'; _grandma_word_frame -1; _grandma_yarn "$FULL"   # settle
+  else
+    _grandma_word_frame -1; _grandma_yarn "$FULL"
+  fi
+}
+
+# grandma_splash — the "grandma pops up" moment before a session or the interview. On a
+# graphics-capable terminal it renders assets/grandma.gif; otherwise it draws the typographic
+# wordmark. Shared by launch and init so every entry point matches. Skip with GRANDMA_NO_SPLASH=1.
+grandma_splash() {
+  [[ "${GRANDMA_NO_SPLASH:-0}" == "1" ]] && return 0
+  local scope="$1" gif="$ENGINE/assets/grandma.gif"
+  local P=$'\033[95m' B=$'\033[1m' D=$'\033[2m' R=$'\033[0m'
+  local shown=0
+  printf '\n'
+  if [[ -f "$gif" ]]; then
+    case "$(pick_mascot_renderer)" in
+      imgcat) imgcat --height "${GRANDMA_SPLASH_HEIGHT:-16}" "$gif" 2>/dev/null && shown=1 ;;
+      chafa)  chafa --animate off --size "${GRANDMA_SPLASH_SIZE:-40x20}" "$gif" 2>/dev/null && shown=1 ;;
+    esac
+  fi
+  if [[ "$shown" == 1 ]]; then
+    printf '  %s%sGRANDMA%s  %sshe remembers everything%s\n' "$B" "$P" "$R" "$D" "$R"   # text under the GIF
+  else
+    grandma_wordmark                                                                    # the wordmark IS the text
+  fi
+  printf '  %sfetching %s memory...%s\n\n' "$D" "$scope" "$R"
+  sleep "${GRANDMA_SPLASH_SECS:-0.7}"
+}
+
 # Emit "rawname<TAB>dir" for each project in a scope's projects.md (dir = folder holding CLAUDE.md).
 project_entries() {
   local reg="$1"

--- a/test/cmd_splash.sh
+++ b/test/cmd_splash.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Behavioral tests for the splash renderer (lib/grandma-lib.sh).
+# The mascot GIF is rendered ONLY on graphics-capable terminals (iTerm2/kitty/WezTerm/sixel);
+# every other terminal (Apple Terminal, plain xterm) gets hand-crafted ANSI art. Pins that
+# split so the "blocky GIF in Apple Terminal" regression cannot return.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE="$(cd "$HERE/.." && pwd)"
+. "$HERE/lib/assert.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/chafa" "$TMP/imgcat" "$TMP/both" "$TMP/none"
+printf '#!/bin/sh\nexit 0\n' > "$TMP/chafa/chafa";   chmod +x "$TMP/chafa/chafa"
+printf '#!/bin/sh\nexit 0\n' > "$TMP/imgcat/imgcat"; chmod +x "$TMP/imgcat/imgcat"
+cp "$TMP/chafa/chafa" "$TMP/both/chafa"; cp "$TMP/imgcat/imgcat" "$TMP/both/imgcat"
+
+# pick <bindir> <TERM_PROGRAM> <TERM> — run pick_mascot_renderer in a controlled environment.
+pick() {
+  capture env -i "PATH=$1:/usr/bin:/bin" "TERM_PROGRAM=$2" "TERM=$3" \
+    bash -c '. "'"$ENGINE"'/lib/grandma-lib.sh"; pick_mascot_renderer'
+}
+
+section "splash — Apple Terminal never renders the GIF (uses ANSI art), even with tools present"
+pick "$TMP/both" "Apple_Terminal" "xterm-256color"
+assert_rc 0 "runs on Apple Terminal"
+assert_not_contains "chafa"  "chafa NOT used on Apple Terminal (blocky-GIF bug stays fixed)"
+assert_not_contains "imgcat" "imgcat NOT used on Apple Terminal"
+
+section "splash — iTerm2 renders the GIF: imgcat preferred, chafa as backup"
+pick "$TMP/imgcat" "iTerm.app" "xterm-256color"
+assert_contains "imgcat" "imgcat used in iTerm2"
+pick "$TMP/chafa" "iTerm.app" "xterm-256color"
+assert_contains "chafa" "chafa used in iTerm2 when imgcat is absent"
+pick "$TMP/both" "iTerm.app" "xterm-256color"
+assert_contains "imgcat" "imgcat preferred over chafa in iTerm2"
+
+section "splash — kitty (a graphics terminal) renders the GIF via chafa"
+pick "$TMP/chafa" "" "xterm-kitty"
+assert_contains "chafa" "chafa used in kitty"
+
+section "splash — graphics terminal but no renderer installed -> ANSI art"
+pick "$TMP/none" "iTerm.app" "xterm-256color"
+assert_not_contains "chafa"  "no tool -> no GIF"
+assert_not_contains "imgcat" "no tool -> no GIF"
+
+section "splash — grandma_splash draws the typographic wordmark when no GIF renders"
+capture env -i "PATH=/usr/bin:/bin" "TERM_PROGRAM=Apple_Terminal" "TERM=xterm-256color" \
+  "GRANDMA_SPLASH_SECS=0" "ENGINE=$ENGINE" \
+  bash -c '. "'"$ENGINE"'/lib/grandma-lib.sh"; grandma_splash "acme"'
+assert_rc 0 "grandma_splash runs from the shared lib"
+assert_contains '/____/' "draws the pre-rendered grandma wordmark"
+assert_contains "she remembers everything" "knits the tagline"
+assert_contains "fetching acme memory" "shows what is loading"
+
+echo
+if [ "$FAILS" -eq 0 ]; then echo "cmd_splash: PASS"; else echo "cmd_splash: $FAILS FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
## What

The mascot now shows in **every** terminal:

- **Graphics-capable terminals** (iTerm2, kitty, WezTerm, sixel) → the real animated `grandma.gif`, unchanged.
- **Every other terminal** (Apple Terminal, VS Code, plain xterm, tmux) → a sharp typographic **`grandma` wordmark**: slant lettering in the mascot's pink→magenta, a **standing knitting needle** with yarn stitches, and the yarn knitting out to *"she remembers everything."*

<!-- 📸 SCREENSHOT: drag the Apple Terminal screenshot here (final result) -->
<img width="608" height="229" alt="Screenshot 2026-07-18 at 11 36 21 AM" src="https://github.com/user-attachments/assets/4e8d92fe-94b2-4802-9840-b1a27aa32e9d" />


Fixes #17.

## Why we couldn't just render the GIF (the blocker)

The mascot previously rendered only through `imgcat`, which is **iTerm2-only**. On Apple Terminal — the default macOS terminal and a huge share of users — it silently fell back to a plain ASCII granny.

The blocker is fundamental, not a config problem: **drawing a real image in a terminal requires the terminal emulator to implement an inline-image protocol** — iTerm2's, kitty's, or sixel. **Apple Terminal.app implements none of them.** A program running inside it has no way to draw pixels, because the capability isn't there to call. This was confirmed three ways:

1. The sixel support tracker lists Apple Terminal as unsupported.
2. Every "images in macOS terminal" guide points to iTerm2/kitty — not Terminal.app.
3. On a real machine, `chafa` auto-detected the terminal and fell back to text blocks, which only happens when no image protocol exists.

Approaches we tried and rejected for Apple Terminal:
- **`chafa`/`tiv` block rendering** — a raster image approximated in character cells + 256 colors reads as blurry and banded; a detailed illustration turns to mush.
- **Higher-resolution sextant/octant glyphs** — render as `□` tofu, because the default terminal fonts (SF Mono/Menlo) don't include those Unicode blocks.
- **A QuickLook popup** (`qlmanage`) — shows the real GIF but in a separate window, breaks over SSH, and is intrusive as a launch splash.

## Why a typographic wordmark

Terminals render **text** perfectly and crisply — so instead of faking a picture, we lean into type. A wordmark:

- is **sharp in every terminal**, including Apple Terminal, with no image protocol required;
- is **on-brand** (same magenta/pink as the mascot, knitting needle + yarn motif);
- needs **zero dependencies** and works over SSH;
- degrades gracefully (static when not on a TTY).

The result reads as intentional and designed, not like a broken image.

## Implementation notes

- **No new dependencies.** The "grandma" lettering is pre-rendered ASCII embedded in the script (figlet is not required at runtime).
- **bash 3.2 compatible** (macOS default) — no `mapfile`, no associative arrays.
- **Animation** (a light shimmer sweeping the letters + the yarn knitting) plays only on a wide interactive TTY; it's **static** on pipes, in tests, and on narrow terminals so nothing corrupts.
- Honors `GRANDMA_NO_SPLASH=1` (skip entirely) and adds `GRANDMA_SPLASH_STATIC=1` (logo without motion / reduced-motion).
- The splash was moved into `lib/grandma-lib.sh` so `launch` and the `init` interview share one implementation; `doctor` and the dry-run manifest report which mode a terminal gets.
- Fixed a latent UTF-8 bug found along the way: a multibyte glyph placed directly after an unbraced `$var` was dropping its lead byte; needle glyphs are now literals in the `printf` format.

## Testing

- Full suite **14/14 pass**, including a new `test/cmd_splash.sh` that pins the split: iTerm2/kitty get the GIF, Apple Terminal never does (regression guard for the blocky-image bug), and the wordmark + tagline render.
- `shellcheck -S warning` clean on all changed files.
- Animation verified to settle cleanly in a real pty; static path verified for non-TTY.

## How to try it

```sh
# Apple Terminal → the wordmark; iTerm2/kitty → the GIF
ENGINE="$PWD" bash -c '. lib/grandma-lib.sh; grandma_splash acme'
```
