### PR TITLE
grandma search: grep across your memory (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- `grandma search [sweater] <query>`: read-only literal grep across your memory, in
+  `file:line:text` form. Uses ripgrep when present and grep otherwise (no new hard
+  dependency), and both engines are made to agree. Exit 0/1/2 follows grep's convention.
+
 ## v0.1.0
 
 First public cut.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ eval "$(grandma completions zsh)"
 
 Start a new shell and press TAB after `grandma`. Grandma does not touch your rc file for you, so turning this on stays your call.
 
+### Search your memory
+
+Sometimes you just want to know what she remembers, without starting a session:
+
+```text
+$ grandma search pnpm
+global/preferences.md:9:- pnpm only, never yarn
+acme/facts.md:4:- pnpm workspaces, one lockfile at the root
+  2 match(es) in 2 file(s)
+
+$ grandma search acme migrations       # scoped to one sweater
+acme/facts.md:6:- Postgres, migrations via atlas only
+  1 match(es) in 1 file(s) · sweater acme
+```
+
+Read-only, and it never starts Claude. Output is `file:line:text`, so it pipes like grep.
+The scoped form searches that sweater alone (not global), so a hit always tells you which
+sweater owns the memory. Matching is a case-insensitive literal string — ripgrep when you
+have it, grep otherwise, and both are made to agree. Exit codes follow grep: `0` matches,
+`1` no matches, `2` bad usage. Pending proposals and watch scratch are not searched; they
+are not memory until you accept them.
+
 ## How it works
 
 Three layers of memory, loaded in the right amounts at the right times:
@@ -158,6 +180,7 @@ grandma <sweater> [project]      launch a remembered session
 grandma init | doctor          setup and health checks
 grandma save <sweater> [project] distill a finished session into memory
 grandma review [sweater]         review what background distills proposed
+grandma search [sweater] <query> grep across your memory
 grandma ingest [sweater]         catalog an existing folder of projects
 grandma watch ...              analysis campaigns over your sessions
 grandma test [sweater]           verify the integrity invariants
@@ -170,8 +193,8 @@ grandma knit                   coming next: share a project's memory with a team
 - **Exit sessions with Ctrl+D**, not `/exit`. Claude Code's `/exit` skips SessionEnd
   hooks (upstream issue), so the end-of-session distill only runs on Ctrl+D. Manual
   fallback always works: `grandma save <sweater>`.
-- Sweater names that collide with subcommands (`init`, `save`, `review`, `ingest`,
-  `watch`, `test`, `doctor`, `help`) are reserved.
+- Sweater names that collide with subcommands (`init`, `save`, `review`, `search`,
+  `ingest`, `watch`, `test`, `doctor`, `help`) are reserved.
 - macOS is the daily-driven platform. Linux is CI-tested but younger: if something
   misbehaves, `grandma doctor` first, then an issue with its output.
 

--- a/bin/grandma
+++ b/bin/grandma
@@ -11,6 +11,7 @@
 #   grandma init                       first-run setup (memory home, PATH, interview)
 #   grandma save <sweater> [project]   distill a finished session into memory
 #   grandma review [sweater]           review auto-distill proposals
+#   grandma search [sweater] <query>   grep across your memory
 #   grandma ingest [sweater] [--root]  catalog a folder of projects into a sweater
 #   grandma watch <start|status|...>   analysis campaigns over your sessions
 #   grandma test [sweater]             verify the context-integrity invariants
@@ -29,10 +30,11 @@ case "$sub" in
   init|doctor)  shift; exec "$ENGINE/lib/grandma-init.sh" "$sub" "$@" ;;
   save)         shift; exec "$ENGINE/lib/grandma-save.sh" "$@" ;;
   review)       shift; exec "$ENGINE/lib/grandma-review.sh" "$@" ;;
+  search)       shift; exec "$ENGINE/lib/grandma-search.sh" "$@" ;;
   ingest)       shift; exec "$ENGINE/lib/grandma-ingest.sh" "$@" ;;
   watch)        shift; exec "$ENGINE/lib/grandma-watch.sh" "$@" ;;
   test)         shift; exec "$ENGINE/lib/grandma-test.sh" "$@" ;;
   completions)  shift; exec "$ENGINE/lib/grandma-completions.sh" "$@" ;;
-  help|-h|--help) sed -n '3,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  help|-h|--help) sed -n '3,23p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
   *)            exec "$ENGINE/lib/grandma-launch.sh" "$@" ;;
 esac

--- a/lib/grandma-completions.sh
+++ b/lib/grandma-completions.sh
@@ -23,7 +23,7 @@ source "$ENGINE/lib/grandma-lib.sh"
 
 # First-word candidates that are NOT sweaters: the reserved subcommands (keep in sync with
 # bin/grandma). A sweater whose name collides with one of these is shadowed, as documented.
-SUBCOMMANDS="init save review ingest watch test doctor completions help"
+SUBCOMMANDS="init save review search ingest watch test doctor completions help"
 
 # _gc_scopes - completable first words: every sweater, then the subcommands.
 _gc_scopes() {

--- a/lib/grandma-search.sh
+++ b/lib/grandma-search.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# grandma-search — grep across your memory.
+#
+# Read-only: it finds things in your memory without opening a session or touching a file.
+#
+# Usage:
+#   grandma search <query...>              search global + every sweater
+#   grandma search <sweater> <query...>    search one sweater only
+#   grandma search --all <query...>        force the every-sweater form
+#
+# The first word counts as a sweater ONLY when it names a real sweater AND at least one
+# more word follows. So a one-word search is always a query, never a sweater, and when a
+# query's first word collides with a sweater name, --all forces the wide read.
+#
+# Scoped search covers that sweater alone — NOT global. "Scoped to one" should mean one,
+# so a hit always tells you which sweater owns the memory. Use the wide form for global.
+#
+# Matching is a case-insensitive FIXED string, not a regex. BSD grep, GNU grep and ripgrep
+# agree on literals but diverge on patterns, and a memory search that answers differently
+# depending on which machine you are sitting at is worse than one that cannot do regex.
+# Multiple words are joined with a single space and matched as one literal.
+#
+# Searched: global/ and each sweater folder. Deliberately NOT searched: proposals/ and
+# watches/ (gitignored scratch — not memory until you accept it) and .distill/ (staged
+# transcripts). Those directories are simply never passed to the search tool, which is
+# also why no --exclude flag is needed: BSD and GNU spell those differently.
+#
+# ripgrep is used when it is on PATH, grep otherwise, so this adds no hard dependency.
+# GRANDMA_SEARCH_TOOL=rg|grep|auto pins the engine (default auto) — the test suite uses
+# it to exercise both paths on one machine.
+#
+# Output: <file>:<line>:<text>, paths relative to GRANDMA_HOME, like grep. A one-line
+# summary goes to stderr, so `grandma search x | ...` pipes only matches.
+#
+# Exit: 0 matches found · 1 no matches (grep's convention, so `grandma search x || ...`
+# works as expected) · 2 usage error.
+
+set -uo pipefail
+ENGINE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="${GRANDMA_HOME:-$HOME/.grandma}"   # the user's private memory home
+source "$ENGINE/lib/grandma-lib.sh"
+
+usage() {
+  cat <<'USAGE'
+usage: grandma search <query...>            search global + every sweater
+       grandma search <sweater> <query...>  search one sweater only
+       grandma search --all <query...>      force the every-sweater form
+
+Matches a case-insensitive literal string. Prints <file>:<line>:<text>.
+Exit 0 = matches, 1 = no matches, 2 = usage error.
+USAGE
+}
+
+# ---- args ----
+ALL=0
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --all)          ALL=1 ;;
+    -h|--help)      usage; exit 0 ;;
+    -*)             echo "unknown flag: $arg" >&2; usage >&2; exit 2 ;;
+    *)              ARGS+=("$arg") ;;
+  esac
+done
+
+if [[ ${#ARGS[@]} -eq 0 ]]; then usage >&2; exit 2; fi
+
+# ---- split off a leading sweater, if that is what it is ----
+SCOPE=""
+if [[ "$ALL" -eq 0 && ${#ARGS[@]} -ge 2 ]] && resolve_scope_dir "${ARGS[0]}" >/dev/null 2>&1; then
+  SCOPE="${ARGS[0]}"
+  ARGS=("${ARGS[@]:1}")
+fi
+QUERY="${ARGS[*]}"
+
+# ---- which directories to search (naming them IS the exclusion of proposals/watches) ----
+DIRS=()
+if [[ -n "$SCOPE" ]]; then
+  # resolve_scope_dir gives the real (case-correct) folder; search it by name, relative to ROOT
+  DIRS=("$(basename "$(resolve_scope_dir "$SCOPE")")")
+else
+  [[ -d "$ROOT/global" ]] && DIRS+=(global)
+  while IFS= read -r s; do [[ -n "$s" ]] && DIRS+=("$s"); done < <(list_scopes)
+fi
+
+if [[ ${#DIRS[@]} -eq 0 ]]; then
+  echo "no memory to search at $ROOT — run 'grandma init', or 'grandma' to knit a sweater." >&2
+  exit 1
+fi
+
+cd "$ROOT" 2>/dev/null || { echo "error: no memory home at $ROOT" >&2; exit 2; }
+
+# ---- pick the engine ----
+TOOL="${GRANDMA_SEARCH_TOOL:-auto}"
+case "$TOOL" in
+  auto)     if command -v rg >/dev/null 2>&1; then TOOL="rg"; else TOOL="grep"; fi ;;
+  rg)       command -v rg >/dev/null 2>&1 || TOOL="grep" ;;   # asked for rg, has none: degrade
+  grep)     ;;
+  *)        echo "unknown GRANDMA_SEARCH_TOOL '$TOOL' (want rg, grep or auto)" >&2; exit 2 ;;
+esac
+
+# --no-ignore keeps ripgrep from honoring the memory repo's .gitignore, so both engines
+# see the same files. -I means "skip binary" to grep but "hide the filename" to ripgrep —
+# hence it goes to grep only; ripgrep skips binary files on its own.
+out=""
+if [[ "$TOOL" == "rg" ]]; then
+  out="$(rg --no-heading --with-filename --line-number --color never --no-ignore --sort path \
+          -F -i -- "$QUERY" ${DIRS[@]+"${DIRS[@]}"} 2>/dev/null)"
+else
+  out="$(grep -rn -I -F -i -- "$QUERY" ${DIRS[@]+"${DIRS[@]}"} 2>/dev/null)"
+fi
+
+if [[ -z "$out" ]]; then
+  printf '  no memory matches "%s"%s\n' "$QUERY" "${SCOPE:+ in $SCOPE}" >&2
+  exit 1
+fi
+
+printf '%s\n' "$out"
+n="$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
+nf="$(printf '%s\n' "$out" | cut -d: -f1 | sort -u | wc -l | tr -d ' ')"
+printf '  %s match(es) in %s file(s)%s\n' "$n" "$nf" "${SCOPE:+ · sweater $SCOPE}" >&2

--- a/lib/grandma-test.sh
+++ b/lib/grandma-test.sh
@@ -18,7 +18,7 @@ ASSEMBLE="$ENGINE/lib/assemble.sh"
 # Scope-agnostic runtime files that must NOT contain scope-specific content: the runtime
 # scripts, and the generic prompts that run across all scopes.
 CORE=(lib/grandma-launch.sh lib/grandma-lib.sh lib/grandma-rehydrate.sh lib/grandma-session-end.sh \
-      lib/grandma-save.sh lib/grandma-ingest.sh lib/grandma-review.sh lib/assemble.sh \
+      lib/grandma-save.sh lib/grandma-ingest.sh lib/grandma-review.sh lib/grandma-search.sh lib/assemble.sh \
       prompts/distiller.md prompts/onboard.md prompts/ingest.md prompts/new-scope.md \
       prompts/capture.md lib/grandma-watch.sh prompts/watch-digest.md prompts/watch-report.md)
 

--- a/test/cmd_search.sh
+++ b/test/cmd_search.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Behavioral tests for `grandma search` — read-only grep across memory.
+#
+# Bites this pins down:
+#   - the KEBAB sweater (home-ops) must resolve whole, not truncate to "home" (the bug class
+#     that already shipped twice here, in review's `cut -d-` and in completions).
+#   - a ONE-word search is always a query, never a sweater, or `grandma search <sweater>`
+#     would silently search that sweater for nothing.
+#   - proposals/ are NOT memory yet, so they must stay out of results.
+#   - rg and grep must agree: the same query is run under both engines below.
+#   - no-match is exit 1 (grep's convention), usage error is exit 2.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE="$(cd "$HERE/.." && pwd)"
+. "$HERE/lib/assert.sh"
+. "$HERE/lib/fixture.sh"
+
+GBIN="$ENGINE/bin/grandma"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+export GRANDMA_HOME="$TMP/home"; export SHELL=""
+make_fixture_home "$GRANDMA_HOME"
+
+# Which engines can we exercise on this machine? grep always; rg only when installed.
+ENGINES="grep"
+command -v rg >/dev/null 2>&1 && ENGINES="grep rg"
+
+for eng in $ENGINES; do
+  export GRANDMA_SEARCH_TOOL="$eng"
+
+  section "search [$eng] — wide search covers global and every sweater"
+  capture env "$GBIN" search pnpm
+  assert_rc 0 "one-word search runs under set -u and finds a match"
+  assert_contains "global/preferences.md" "reaches global memory"
+  capture env "$GBIN" search facts
+  assert_rc 0 "a term in two sweaters searches both"
+  assert_contains "globex/facts.md" "finds the plain sweater"
+  assert_contains "home-ops/facts.md" "finds the kebab sweater"
+
+  section "search [$eng] — output is file:line:text, like grep"
+  capture env "$GBIN" search atlas
+  assert_rc 0 "finds a sweater fact"
+  case "$LAST_OUT" in
+    *"globex/facts.md:"[0-9]*":"*) ok "prints <file>:<line>:<text> with a path relative to the home" ;;
+    *) fail "expected file:line:text output" "$LAST_OUT" ;;
+  esac
+  assert_contains "match(es) in" "prints a summary count"
+
+  section "search [$eng] — scoped to one sweater"
+  capture env "$GBIN" search home-ops facts
+  assert_rc 0 "scoped search resolves the KEBAB sweater whole (not truncated to 'home')"
+  assert_contains "home-ops/facts.md" "returns the named sweater's hit"
+  assert_not_contains "globex/facts.md" "does not leak the other sweater"
+  capture env "$GBIN" search home-ops trash
+  assert_rc 0 "scoped search finds a fact unique to that sweater"
+
+  section "search [$eng] — scoped means that sweater ALONE, not global"
+  capture env "$GBIN" search globex pnpm
+  assert_rc 1 "a global-only term is absent from a scoped search"
+
+  section "search [$eng] — a one-word search is a query, never a sweater"
+  capture env "$GBIN" search globex
+  assert_rc 0 "bare sweater name searches FOR the word instead of scoping to it"
+  assert_contains "globex/facts.md" "matches the word where it appears in memory"
+
+  section "search [$eng] — --all forces the wide read"
+  # Without --all this scopes to home-ops and matches the log; with it, the literal
+  # string "home-ops planted" is searched, which appears nowhere.
+  capture env "$GBIN" search home-ops planted
+  assert_rc 0 "without --all, a leading sweater name scopes the search"
+  capture env "$GBIN" search --all home-ops planted
+  assert_rc 1 "with --all, the sweater name is part of the query instead"
+
+  section "search [$eng] — matching is literal, case-insensitive, multi-word"
+  capture env "$GBIN" search PNPM
+  assert_rc 0 "case-insensitive"
+  capture env "$GBIN" search never yarn
+  assert_rc 0 "multiple words join into one literal phrase"
+  assert_contains "global/preferences.md" "finds the phrase"
+  capture env "$GBIN" search "yarn never"
+  assert_rc 1 "the phrase is literal, not a set of words in any order"
+
+  section "search [$eng] — proposals are not memory yet, so they stay out"
+  assert_file "$GRANDMA_HOME/proposals/home-ops-20260601T101010.md" "fixture has a proposal to exclude"
+  capture env "$GBIN" search recycling
+  assert_rc 1 "a term that exists ONLY in proposals/ does not match"
+
+  section "search [$eng] — no match and bad usage are graceful"
+  capture env "$GBIN" search definitely-not-in-any-memory
+  assert_rc 1 "no match exits 1, grep's convention"
+  assert_contains "no memory matches" "says so plainly"
+  capture env "$GBIN" search definitely-not-a-scope facts
+  assert_rc 1 "an unknown leading word is treated as query text, not a sweater"
+  capture env "$GBIN" search
+  assert_rc 2 "bare 'search' prints usage and exits 2"
+  assert_contains "usage: grandma search" "prints usage"
+  capture env "$GBIN" search --nope pnpm
+  assert_rc 2 "an unknown flag exits 2"
+done
+unset GRANDMA_SEARCH_TOOL
+
+section "search — rg and grep return the same matches"
+if command -v rg >/dev/null 2>&1; then
+  g="$(env GRANDMA_SEARCH_TOOL=grep "$GBIN" search facts 2>/dev/null | sort)"
+  r="$(env GRANDMA_SEARCH_TOOL=rg   "$GBIN" search facts 2>/dev/null | sort)"
+  [ "$g" = "$r" ] && ok "both engines agree on the same query" \
+    || fail "engine outputs differ" "grep:
+$g
+rg:
+$r"
+else
+  skip "ripgrep not installed — grep path covered above"
+fi
+
+section "search — wired into the CLI surface"
+capture env "$GBIN" help
+assert_rc 0 "help runs"
+assert_contains "grandma search" "help lists the search subcommand"
+assert_contains "grandma completions" "help block range still reaches the last usage line"
+capture env "$GBIN" completions __scopes
+assert_contains "search" "tab-completion offers search as a first word"
+
+echo
+if [ "$FAILS" -eq 0 ]; then echo "cmd_search: PASS"; else echo "cmd_search: $FAILS FAILURE(S)"; exit 1; fi

--- a/test/cmd_search.sh
+++ b/test/cmd_search.sh
@@ -111,6 +111,27 @@ else
   skip "ripgrep not installed — grep path covered above"
 fi
 
+section "search — degrades and refuses cleanly"
+capture env GRANDMA_SEARCH_TOOL=ack "$GBIN" search pnpm
+assert_rc 2 "an unknown GRANDMA_SEARCH_TOOL is refused, not silently ignored"
+assert_contains "unknown GRANDMA_SEARCH_TOOL" "names the bad value"
+# Asking for rg on a box without it must fall back to grep, not die. /usr/bin:/bin has the
+# coreutils this command needs and (on any normal machine) no rg.
+capture env PATH=/usr/bin:/bin GRANDMA_SEARCH_TOOL=rg "$GBIN" search pnpm
+assert_rc 0 "GRANDMA_SEARCH_TOOL=rg with no rg on PATH degrades to grep"
+assert_contains "global/preferences.md" "and still returns the match"
+capture env "$GBIN" search --help
+assert_rc 0 "--help exits 0"
+assert_contains "usage: grandma search" "and prints the usage"
+
+section "search — an empty or missing memory home says so, and does not crash"
+capture env GRANDMA_HOME="$TMP/does-not-exist" "$GBIN" search pnpm
+assert_rc 1 "a missing memory home is 'nothing found', not a crash"
+assert_contains "no memory to search" "explains what to do about it"
+mkdir -p "$TMP/bare"
+capture env GRANDMA_HOME="$TMP/bare" "$GBIN" search pnpm
+assert_rc 1 "a home with no global/ and no sweaters is the same"
+
 section "search — wired into the CLI surface"
 capture env "$GBIN" help
 assert_rc 0 "help runs"


### PR DESCRIPTION
Closes #8.

A read-only way to find things in memory without opening a session.

```text
$ grandma search pnpm
global/preferences.md:9:- pnpm only, never yarn
acme/facts.md:4:- pnpm workspaces, one lockfile at the root
  2 match(es) in 2 file(s)

$ grandma search acme migrations       # scoped to one sweater
acme/facts.md:6:- Postgres, migrations via atlas only
  1 match(es) in 1 file(s) · sweater acme
```

## Shape

As the issue laid out: new `lib/grandma-search.sh`, a dispatch case in `bin/grandma`, a usage line in the help block (the `sed -n` range moved with it), plus `search` added to the completion subcommands and the README's reserved-names list.

## Decisions the issue left open

- **Exit codes follow grep**: `0` matches, `1` no matches, `2` usage error — so `grandma search x || echo none` behaves the way a shell user expects. Documented in the file header, the `--help` output, and the README.
- **Matching is a case-insensitive fixed string, not a regex.** BSD grep, GNU grep and ripgrep agree on literals but diverge on patterns, and a memory search that answers differently depending on which machine you are sitting at seemed worse than one that cannot do regex. Multiple words join into one literal phrase.
- **A scoped search covers that sweater alone, not global.** "Scoped to one" should mean one, so a hit always tells you which sweater owns the memory. The wide form covers global.
- **The first word counts as a sweater only when it names a real one AND more words follow**, so a one-word search is always a query — otherwise `grandma search <sweater>` would silently search that sweater for nothing. `--all` forces the wide read when a query's first word collides with a sweater name.
- **`proposals/` and `watches/` are not searched.** They are not memory until you accept them.

## Portability

- ripgrep when it is on PATH, grep otherwise, so no new hard dependency. `GRANDMA_SEARCH_TOOL=rg|grep|auto` pins the engine; the test suite uses it to run every assertion under **both**.
- `--no-ignore` keeps ripgrep from honoring the memory repo's `.gitignore`, so both engines see the same files.
- `-I` is passed to grep only: it means "skip binary" to grep but "hide the filename" to ripgrep, which would have broken the output shape. ripgrep skips binaries on its own.
- The excluded directories are excluded by *never being passed to the search tool*, rather than by an `--exclude` flag — BSD and GNU spell those differently.

## Definition of done

- `test/cmd_search.sh` runs every assertion under both engines and asserts they return identical matches for the same query.
- Name parsing is pinned against the **kebab** fixture sweater: `grandma search home-ops facts` must resolve `home-ops` whole and not truncate to `home` (the bug class that already shipped twice here).
- Also pinned: the `proposals/` exclusion, all three exit codes, the one-word-is-a-query rule, `--all`, literal multi-word matching, and that `help` still reaches its last usage line after the range change.
- Everything survives `set -u` (`assert_rc` checks this on every call).
- Rule 1 is respected: `lib/grandma-search.sh` is added to the `CORE` purity list in `lib/grandma-test.sh`, so a context leak into it fails check 2/3.
- Bash 3.2 safe: empty-array expansion guarded with `${arr[@]+"${arr[@]}"}`.
- `shellcheck -S warning` clean across the files CI lints, and `./test/run.sh` is green (16/16 suites) locally on macOS.

Rules 4 and the dry-run half of DoD 1 do not apply: `search` spawns no model call and never execs `claude`.