### PR TITLE
watch: tool-usage lens (per-tool call counts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- `grandma watch`: tool-usage lens. Metrics now count calls per tool name, not just the
+  total, so `grandma watch status` shows your top tools live and the final report can
+  reason about the mix. Mechanical (python over the transcript), no model call.
+
 - `grandma update` / `grandma version`: update the engine in place with a fast-forward pull
   (never forces), and print the running version (the `VERSION` file plus the commit). No server
   and no telemetry: instead of checking anywhere, grandma prints one quiet launch line when your

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - `grandma watch`: tool-usage lens. Metrics now count calls per tool name, not just the
   total, so `grandma watch status` shows your top tools live and the final report can
   reason about the mix. Mechanical (python over the transcript), no model call.
-
 - `grandma update` / `grandma version`: update the engine in place with a fast-forward pull
   (never forces), and print the running version (the `VERSION` file plus the commit). No server
   and no telemetry: instead of checking anywhere, grandma prints one quiet launch line when your

--- a/lib/grandma-watch.sh
+++ b/lib/grandma-watch.sh
@@ -86,6 +86,26 @@ import json,sys
 d=json.load(open('$1')); d['$2']=$3
 json.dump(d,open('$1','w'),indent=1)" 2>/dev/null; }
 
+# top tools across a metrics.jsonl, as "Bash=41 Edit=12 Read=9" (empty if none counted).
+# Rows written before the tool lens have no "tools" key and are simply skipped.
+top_tools() { # metrics.jsonl [limit]
+  [[ -f "$1" ]] || return 0
+  python3 - "$1" "${2:-8}" <<'PY'
+import json, sys
+path, limit = sys.argv[1], int(sys.argv[2])
+counts = {}
+for line in open(path):
+    line = line.strip()
+    if not line: continue
+    try: r = json.loads(line)
+    except Exception: continue
+    for name, n in (r.get("tools") or {}).items():
+        counts[name] = counts.get(name, 0) + n
+top = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:limit]
+print(" ".join(f"{name}={n}" for name, n in top))
+PY
+}
+
 # transcripts touched within the watch window, optional scope substring filter
 find_transcripts() { # start_epoch scope_filter
   local start="$1" scope="$2" f
@@ -149,7 +169,7 @@ for p in paths:
     m = {"session": sid, "mtime": mtime, "project": os.path.basename(os.path.dirname(p)),
          "user_turns": 0, "assistant_turns": 0, "tool_calls": 0, "compactions": 0,
          "in_tok": 0, "out_tok": 0, "cache_read": 0, "cache_create": 0,
-         "models": [], "t0": None, "t1": None}
+         "models": [], "tools": {}, "t0": None, "t1": None}
     models = set()
     try:
         for line in open(p, errors="replace"):
@@ -176,6 +196,8 @@ for p in paths:
                 for b in (msg.get("content") or []):
                     if isinstance(b, dict) and b.get("type") == "tool_use":
                         m["tool_calls"] += 1
+                        name = b.get("name") or "?"
+                        m["tools"][name] = m["tools"].get(name, 0) + 1
     except Exception:
         continue
     m["models"] = sorted(models)
@@ -258,7 +280,7 @@ $(cat "$dir/.work/batch.md")" \
 
   # ---- 3. deadline passed -> synthesize the report ----
   if [[ "$now" -ge "$end" && ! -f "$dir/report.md" && -n "${CB:-}" ]]; then
-    python3 - "$dir" > "$dir/.work/metrics-summary.md" <<'PY'
+    { python3 - "$dir" <<'PY'
 import json, os, sys
 d = sys.argv[1]
 rows = [json.loads(l) for l in open(os.path.join(d, "data", "metrics.jsonl")) if l.strip()]
@@ -277,6 +299,11 @@ for r in rows:
           f"{r.get('compactions')} | {r.get('in_tok')} | {r.get('out_tok')} | {r.get('cache_read')} | "
           f"{','.join(r.get('models') or [])}")
 PY
+      echo
+      echo "tool usage (all sessions, most used first):"
+      local tools; tools="$(top_tools "$dir/data/metrics.jsonl" 20)"
+      echo "${tools:-(none counted)}"
+    } > "$dir/.work/metrics-summary.md"
     local RSYS
     RSYS="$(cat "$ENGINE/prompts/watch-report.md")
 
@@ -326,6 +353,8 @@ cmd_status() {
     echo "  question:  $(watch_field "$sj" question)"
     echo "  window:    $(epoch_date "$(watch_field "$sj" start)") -> $(epoch_date "$(watch_field "$sj" end)")"
     echo "  progress:  $n sessions measured, $dn digested"
+    local tools; tools="$(top_tools "$sdir/data/metrics.jsonl")"
+    [[ -n "$tools" ]] && echo "  top tools: $tools"
     [[ -f "$sdir/report.md" ]] && echo "  report:    $sdir/report.md"
   done
   return 0

--- a/lib/grandma-watch.sh
+++ b/lib/grandma-watch.sh
@@ -164,7 +164,9 @@ if os.path.exists(mpath):
 for p in paths:
     sid = os.path.basename(p)[:-6]
     mtime = int(os.path.getmtime(p))
-    if sid in old and old[sid].get("mtime") == mtime:
+    # rows written before the tool lens have no "tools" key: re-parse them once, then
+    # the mtime shortcut resumes as before.
+    if sid in old and old[sid].get("mtime") == mtime and "tools" in old[sid]:
         continue
     m = {"session": sid, "mtime": mtime, "project": os.path.basename(os.path.dirname(p)),
          "user_turns": 0, "assistant_turns": 0, "tool_calls": 0, "compactions": 0,

--- a/prompts/watch-report.md
+++ b/prompts/watch-report.md
@@ -11,6 +11,7 @@ Write `report.md` content with exactly these sections:
    the conclusion.
 2. **The numbers** — the handful of quantitative facts that matter (from the metrics),
    in a small table. Trends over the window if visible (e.g. sessions getting longer).
+   Include the tool mix when it bears on the question (e.g. mostly Bash, little Read).
 3. **Patterns found** — the recurring behaviors behind the numbers, most impactful
    first. Each pattern: what happens, evidence (which sessions, how often), cost.
 4. **What to change** — concrete, testable recommendations ranked by expected impact.

--- a/test/cmd_watch.sh
+++ b/test/cmd_watch.sh
@@ -49,6 +49,37 @@ capture env "$GBIN" watch status
 assert_rc 0 "watch status runs"
 assert_contains "sessions measured" "status reports progress"
 
+section "watch — tool lens counts calls per tool name"
+# A second session with two Edit calls, so the breakdown has something to rank.
+sess2="$HOME/.claude/projects/-tmp-proj-two/sess2.jsonl"
+seed_claude_project "$HOME" "-tmp-proj-two" "sess2" >/dev/null
+cat >> "$sess2" <<'JSONL'
+{"type":"assistant","timestamp":"2026-06-15T11:00:00.000Z","message":{"role":"assistant","model":"claude-test","usage":{},"content":[{"type":"tool_use","name":"Edit","input":{}},{"type":"tool_use","name":"Edit","input":{}}]}}
+JSONL
+capture env PATH="/usr/bin:/bin" "$GBIN" watch tick
+assert_rc 0 "tick with a second session runs"
+# shellcheck disable=SC2034  # LAST_OUT is read by assert_* (sourced from lib/assert.sh)
+LAST_OUT="$(cat "$GRANDMA_HOME/watches/$slug/data/metrics.jsonl")"
+assert_contains '"Bash": 1' "records the per-tool name, not just the total"
+assert_contains '"Edit": 2' "counts repeated calls to the same tool"
+
+capture env "$GBIN" watch status
+assert_rc 0 "status runs with tool counts"
+assert_contains "top tools: Bash=2 Edit=2" "status ranks tools by call count"
+
+section "watch — report synthesis feeds the tool lens to the model, guard intact"
+FB="$TMP/fakebin"; make_fake_claude "$FB" >/dev/null
+capture env PATH="$FB:/usr/bin:/bin" "$GBIN" watch finish "$slug"
+assert_rc 0 "finish synthesizes a report"
+assert_file "$GRANDMA_HOME/watches/$slug/.work/metrics-summary.md" "writes the metrics summary"
+# shellcheck disable=SC2034  # LAST_OUT is read by assert_* (sourced from lib/assert.sh)
+LAST_OUT="$(cat "$GRANDMA_HOME/watches/$slug/.work/metrics-summary.md")"
+assert_contains "tool usage (all sessions" "summary carries the tool breakdown"
+assert_contains "Bash=2 Edit=2" "summary lists the ranked tools"
+# shellcheck disable=SC2034
+LAST_OUT="$(cat "$GRANDMA_HOME/watches/$slug/report.md")"
+assert_contains "distilling=1" "synthesis child inherits the recursion guard"
+
 section "watch — notify-test delivers via a backend (issue #4)"
 # Shadow osascript with a failing stub (neutralizes the real macOS notifier so the suite
 # never pops a live notification) and provide a fake notify-send that just succeeds.

--- a/test/cmd_watch.sh
+++ b/test/cmd_watch.sh
@@ -67,6 +67,22 @@ capture env "$GBIN" watch status
 assert_rc 0 "status runs with tool counts"
 assert_contains "top tools: Bash=2 Edit=2" "status ranks tools by call count"
 
+section "watch — a row written before the tool lens is backfilled, not skipped"
+# Strip the key to fake a pre-lens row: same mtime, so only the "tools" check saves it.
+mfile="$GRANDMA_HOME/watches/$slug/data/metrics.jsonl"
+python3 - "$mfile" <<'PY'
+import json, sys
+rows = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+for r in rows: r.pop("tools", None)
+open(sys.argv[1], "w").write("".join(json.dumps(r) + "\n" for r in rows))
+PY
+capture env PATH="/usr/bin:/bin" "$GBIN" watch tick
+assert_rc 0 "tick runs over rows missing the tool counts"
+# shellcheck disable=SC2034  # LAST_OUT is read by assert_* (sourced from lib/assert.sh)
+LAST_OUT="$(cat "$mfile")"
+assert_contains '"Bash": 1' "re-parses the old row instead of skipping it on mtime"
+assert_contains '"Edit": 2' "backfilled counts match a freshly measured session"
+
 section "watch — report synthesis feeds the tool lens to the model, guard intact"
 FB="$TMP/fakebin"; make_fake_claude "$FB" >/dev/null
 capture env PATH="$FB:/usr/bin:/bin" "$GBIN" watch finish "$slug"


### PR DESCRIPTION
Closes #11.

A watch lens on the metrics-only path: tool usage. No headless model call, so no new
recursion-guard, cost-cap, or lockfile surface.

- Metrics rows gain `"tools": {"Bash": 41, "Edit": 12}` — `tool_use` blocks counted by
  name, not only totalled. New `top_tools` helper ranks them; rows written before this
  change have no `tools` key and are skipped, not crashed on.
- `grandma watch status` prints `top tools:`, so the lens is useful with no `claude` on
  PATH at all. The synthesis input gains the same block, and `watch-report.md` asks for
  the tool mix when it bears on the question.

Tests in `test/cmd_watch.sh`: a second seeded transcript proves per-tool counts and the
ranking in `status`; a `finish` run under the fake-claude shim proves the summary carries
the tools and that `report.md` contains `distilling=1`, i.e. the guard actually reached
the child. `test/run.sh` passes on macOS.

Skipped: per-tool columns in the per-session table. The ranked totals are what the report
reasons over.