### PR TITLE
Fix four scope-resolution and hook-quoting bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- Fixed: only a real sweater can be loaded. Any top-level directory in the memory home used to
+  resolve as one, so `grandma proposals` assembled every sweater's pending proposals into a
+  single session. Resolution now goes through `list_scopes`, in both the launcher and
+  `assemble.sh`.
+- Fixed: hook commands are quoted. A project whose registered name contains a space or a
+  parenthesis produced a `settings.local.json` command that died with a shell syntax error, so
+  that project's end-of-session distill and pre-compaction checkpoint never ran, and never said
+  so. Re-launching now also replaces a stale command instead of adding a correct one beside it.
+- Fixed: a sweater sees exactly its own proposals. Filenames were built from the scope as typed
+  while readers matched case-sensitively (so `grandma Aarc` wrote a proposal `grandma review
+  aarc` could not find), and matching was by bare prefix (so reviewing `home` listed `home-ops`
+  proposals and `--clear` would have deleted them). Proposals are now matched on the `scope=`
+  header the distiller writes inside them, which is exact.
+- Fixed: `grandma` refuses to knit a sweater named after a word the engine uses in its own
+  logic. Such a name makes `grandma test` fail permanently, with a rename as the only cure.
+
 - `grandma watch`: tool-usage lens. Metrics now count calls per tool name, not just the
   total, so `grandma watch status` shows your top tools live and the final report can
   reason about the mix. Mechanical (python over the transcript), no model call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@
   aarc` could not find), and matching was by bare prefix (so reviewing `home` listed `home-ops`
   proposals and `--clear` would have deleted them). Proposals are now matched on the `scope=`
   header the distiller writes inside them, which is exact.
-- Fixed: `grandma` refuses to knit a sweater named after a word the engine uses in its own
-  logic. Such a name makes `grandma test` fail permanently, with a rename as the only cure.
+- Fixed: `grandma` refuses to knit a sweater whose name is structurally unusable, meaning a
+  subcommand (it would be shadowed and never launch) or a folder grandma owns in your memory
+  home (loading it would assemble whatever is inside). A folder that exists but carries no
+  `scope:` frontmatter now says so instead of offering to knit over it.
 
 - `grandma watch`: tool-usage lens. Metrics now count calls per tool name, not just the
   total, so `grandma watch status` shows your top tools live and the final report can

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,25 @@ session does not degrade into an agent that forgot who you are.
 
 The suite runs as a git pre-commit gate on the engine and in CI on macOS and Linux.
 
+### A known limit in the purity check
+
+Check 2 greps each sweater name as a whole word against the engine's source, and it counts
+prompt files as source. Prompt files are prose, full of example words. So a sweater named
+after an ordinary word fails it: `work` matches ten files, and `job-search`, `reddit` and
+`acme` all match too, which is unfortunate given those are the examples the README and the
+new-sweater prompt hand people.
+
+This is a false positive, not a leak. A leak is engine LOGIC branching on a sweater name.
+A prompt that says "an area like job-search" is documentation. The real fix is to narrow
+check 2 to executable logic, and to purge the example words from prompt prose per the rule
+this repo already sets for itself. Until then, naming a sweater after a common word makes
+`grandma test` fail with no cure but a rename.
+
+Grandma does NOT try to prevent this by refusing such names. That was tried and reverted:
+refusing every word the engine mentions rejected the names the product recommends, which is
+worse than the problem. Only structurally impossible names are refused, the subcommands and
+the folders grandma owns inside the memory home.
+
 ## War stories, kept on purpose
 
 Grandma's guards were not designed in advance. Each one is a scar, and knowing them is

--- a/lib/assemble.sh
+++ b/lib/assemble.sh
@@ -20,7 +20,9 @@
 
 set -euo pipefail
 
+ENGINE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT="${GRANDMA_HOME:-$HOME/.grandma}"   # the user's private memory home
+source "$ENGINE/lib/grandma-lib.sh"      # list_scopes / resolve_scope_dir
 
 # ---- args ----
 SCOPE=""
@@ -38,24 +40,16 @@ done
 if [[ -z "$SCOPE" ]]; then
   echo "usage: $(basename "$0") <scope> [--full] [--writing]" >&2
   echo "scopes:" >&2
-  for d in "$ROOT"/*/; do
-    name="$(basename "$d")"
-    [[ "$name" == "global" || "$name" == ".git" ]] && continue
-    echo "  - $name" >&2
-  done
+  while IFS= read -r name; do [[ -n "$name" ]] && echo "  - $name" >&2; done < <(list_scopes)
   exit 2
 fi
 
-# ---- resolve scope dir (case-insensitive), excluding global ----
-SCOPE_DIR=""
-for d in "$ROOT"/*/; do
-  name="$(basename "$d")"
-  [[ "$name" == "global" ]] && continue
-  if [[ "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" == "$(printf '%s' "$SCOPE" | tr '[:upper:]' '[:lower:]')" ]]; then
-    SCOPE_DIR="${d%/}"
-    break
-  fi
-done
+# ---- resolve scope dir (case-insensitive) ----
+# Through list_scopes, so ONLY a real sweater can be assembled. Matching any directory here
+# meant `assemble proposals` emitted every sweater's pending proposals as one bundle, which
+# is precisely the cross-scope leak the isolation invariant exists to prevent — and it could
+# not see it, because it only ever tests the names list_scopes returns.
+SCOPE_DIR="$(resolve_scope_dir "$SCOPE" 2>/dev/null || true)"
 
 if [[ -z "$SCOPE_DIR" ]]; then
   echo "error: no scope matching '$SCOPE' under $ROOT" >&2

--- a/lib/grandma-launch.sh
+++ b/lib/grandma-launch.sh
@@ -314,9 +314,19 @@ if ! resolve_scope_dir "$SCOPE" >/dev/null 2>&1; then
   # engine uses in its own logic fails `grandma test` forever, so offering to knit one (or
   # telling a script to go knit one) is inviting a break that only a rename undoes.
   if scope_name_is_reserved "$SCOPE"; then
-    printf "\n  '%s' is a word grandma's own engine uses, so a sweater by that name would\n" "$SCOPE" >&2
-    printf "  permanently fail 'grandma test'. Pick another name for it.\n\n" >&2
+    printf "\n  '%s' is a name grandma reserves (a subcommand, or a folder it owns in your\n" "$SCOPE" >&2
+    printf "  memory home), so a sweater by that name could never be loaded. Pick another.\n\n" >&2
     exit 2
+  fi
+  # A directory IS there, it just has no `scope:` frontmatter, so nothing treats it as a
+  # sweater: not the picker, not the integrity suite, and now not the launcher either. Say
+  # that plainly. Offering to knit it, or saying "no sweater yet", would read as "your memory
+  # is gone" to someone whose files are sitting right there.
+  if [[ -d "$ROOT/$SCOPE" ]]; then
+    printf "\n  '%s' is a folder in your memory home, but no file in it carries a\n" "$SCOPE" >&2
+    printf "  'scope: %s' frontmatter line, so grandma does not treat it as a sweater.\n" "$SCOPE" >&2
+    printf "  Add that line to %s/facts.md (or any .md directly inside it) and re-run.\n\n" "$SCOPE" >&2
+    exit 1
   fi
   if [[ -t 0 && "${GRANDMA_DRY_RUN:-0}" != "1" ]]; then
     printf "\n  no sweater '%s' yet. knit it now? [Y/n] " "$SCOPE" >&2

--- a/lib/grandma-launch.sh
+++ b/lib/grandma-launch.sh
@@ -35,6 +35,13 @@ source "$ENGINE/lib/grandma-lib.sh"
 # CLI (as in `grandma <name>`), used as the suggested sweater name so the flow proposes it.
 create_new_scope() {
   local suggested="${1:-}"
+  # A name the engine already uses as a word would make `grandma test` fail forever, and the
+  # only cure once memory lives under it is a rename. Refuse up front instead.
+  if [[ -n "$suggested" ]] && scope_name_is_reserved "$suggested"; then
+    printf "\n  '%s' is a word grandma's own engine uses, so a sweater by that name would\n" "$suggested" >&2
+    printf "  permanently fail 'grandma test'. Pick another name for it.\n" >&2
+    exit 2
+  fi
   if [[ -n "$suggested" ]]; then
     printf "\n  Let's knit the '%s' sweater. In a sentence, what is it?\n  (a company, a client, a platform, or an area of your life)\n  > " "$suggested" >&2
   else
@@ -108,17 +115,10 @@ install_rehydrate_hook() {
   local dir="$1" scope="$2"
   [[ "${GRANDMA_NO_HOOK:-0}" == "1" ]] && return 0
   command -v jq >/dev/null 2>&1 || return 0   # jq required; skip quietly if absent
-  local cfg="$dir/.claude/settings.local.json"
-  local cmd="$ENGINE/lib/grandma-rehydrate.sh $scope"
-  local base present
-  base="$(cat "$cfg" 2>/dev/null || echo '{}')"
-  present="$(printf '%s' "$base" | jq -r --arg c "$cmd" \
-    '[.hooks.SessionStart[]? | select(.matcher=="compact") | .hooks[]? | .command] | map(. == $c) | any' 2>/dev/null || echo false)"
-  [[ "$present" == "true" ]] && return 0
-  mkdir -p "$dir/.claude"
-  printf '%s' "$base" | jq --arg c "$cmd" \
-    '.hooks = (.hooks // {}) | .hooks.SessionStart = ((.hooks.SessionStart // []) + [{"matcher":"compact","hooks":[{"type":"command","command":$c,"timeout":15}]}])' \
-    > "$cfg.tmp" 2>/dev/null && mv "$cfg.tmp" "$cfg" && GRANDMA_HOOK_INSTALLED=1
+  local script="$ENGINE/lib/grandma-rehydrate.sh"
+  install_hook "$dir/.claude/settings.local.json" SessionStart compact \
+    "$script" "$(hook_cmd "$script" "$scope")" 15 0 && GRANDMA_HOOK_INSTALLED=1
+  return 0
 }
 
 # Ensure a grandma-launched project has the SessionEnd auto-distill hook (async), so
@@ -128,17 +128,10 @@ install_session_end_hook() {
   local dir="$1" scope="$2" project="$3"
   [[ "${GRANDMA_NO_HOOK:-0}" == "1" || "${GRANDMA_NO_AUTOSAVE:-0}" == "1" ]] && return 0
   command -v jq >/dev/null 2>&1 || return 0
-  local cfg="$dir/.claude/settings.local.json"
-  local cmd="$ENGINE/lib/grandma-session-end.sh $scope $project"
-  local base present
-  base="$(cat "$cfg" 2>/dev/null || echo '{}')"
-  present="$(printf '%s' "$base" | jq -r --arg c "$cmd" \
-    '[.hooks.SessionEnd[]? | .hooks[]? | .command] | map(. == $c) | any' 2>/dev/null || echo false)"
-  [[ "$present" == "true" ]] && return 0
-  mkdir -p "$dir/.claude"
-  printf '%s' "$base" | jq --arg c "$cmd" \
-    '.hooks = (.hooks // {}) | .hooks.SessionEnd = ((.hooks.SessionEnd // []) + [{"matcher":"","hooks":[{"type":"command","command":$c,"async":true,"timeout":600}]}])' \
-    > "$cfg.tmp" 2>/dev/null && mv "$cfg.tmp" "$cfg" && GRANDMA_AUTOSAVE_INSTALLED=1
+  local script="$ENGINE/lib/grandma-session-end.sh"
+  install_hook "$dir/.claude/settings.local.json" SessionEnd "" \
+    "$script" "$(hook_cmd "$script" "$scope" "$project")" 600 1 && GRANDMA_AUTOSAVE_INSTALLED=1
+  return 0
 }
 
 # Ensure a grandma-launched project has the PreCompact checkpoint hook (synchronous), so the
@@ -149,17 +142,10 @@ install_precompact_hook() {
   local dir="$1" scope="$2" project="$3"
   [[ "${GRANDMA_NO_HOOK:-0}" == "1" || "${GRANDMA_NO_AUTOSAVE:-0}" == "1" || "${GRANDMA_NO_CHECKPOINT:-0}" == "1" ]] && return 0
   command -v jq >/dev/null 2>&1 || return 0
-  local cfg="$dir/.claude/settings.local.json"
-  local cmd="$ENGINE/lib/grandma-precompact.sh $scope $project"
-  local base present
-  base="$(cat "$cfg" 2>/dev/null || echo '{}')"
-  present="$(printf '%s' "$base" | jq -r --arg c "$cmd" \
-    '[.hooks.PreCompact[]? | .hooks[]? | .command] | map(. == $c) | any' 2>/dev/null || echo false)"
-  [[ "$present" == "true" ]] && return 0
-  mkdir -p "$dir/.claude"
-  printf '%s' "$base" | jq --arg c "$cmd" \
-    '.hooks = (.hooks // {}) | .hooks.PreCompact = ((.hooks.PreCompact // []) + [{"matcher":"","hooks":[{"type":"command","command":$c,"timeout":60}]}])' \
-    > "$cfg.tmp" 2>/dev/null && mv "$cfg.tmp" "$cfg" && GRANDMA_CHECKPOINT_INSTALLED=1
+  local script="$ENGINE/lib/grandma-precompact.sh"
+  install_hook "$dir/.claude/settings.local.json" PreCompact "" \
+    "$script" "$(hook_cmd "$script" "$scope" "$project")" 60 0 && GRANDMA_CHECKPOINT_INSTALLED=1
+  return 0
 }
 
 # Common parent folder of a scope's registered projects (for onboarding new projects).
@@ -440,8 +426,9 @@ if [[ "${GRANDMA_DRY_RUN:-0}" == "1" ]]; then
     fi
   fi
   [[ ${#PASSTHRU[@]} -gt 0 ]] && echo "passthru:     ${PASSTHRU[*]} (forwarded to claude)" >&2
-  if compgen -G "$ROOT/proposals/${SCOPE}*.md" >/dev/null 2>&1; then
-    pn="$(ls -1 "$ROOT/proposals/${SCOPE}"*.md 2>/dev/null | wc -l | tr -d ' ')"
+  read_proposals "$SCOPE"
+  if [[ ${#PROPOSAL_FILES[@]} -gt 0 ]]; then
+    pn="${#PROPOSAL_FILES[@]}"
     echo "review:       $pn pending proposal(s) — accepting the offer execs: grandma review --apply $SCOPE" >&2
   fi
   echo "capture:      doctrine loaded (prompts/capture.md) · grandma repo writable via --add-dir" >&2
@@ -465,8 +452,9 @@ fi
 # Pending memory proposals for this scope (e.g. from a session whose window was closed, so
 # it distilled in the background). On a real terminal, OFFER to review them before we start —
 # this is where a window-closed session actually gets reviewed. Non-interactive: passive notice.
-if compgen -G "$ROOT/proposals/${SCOPE}*.md" >/dev/null 2>&1; then
-  n="$(ls -1 "$ROOT/proposals/${SCOPE}"*.md 2>/dev/null | wc -l | tr -d ' ')"
+read_proposals "$SCOPE"
+if [[ ${#PROPOSAL_FILES[@]} -gt 0 ]]; then
+  n="${#PROPOSAL_FILES[@]}"
   if [ -t 0 ]; then
     printf '  🧶 grandma noted %s thing(s) from a previous session — review before we start? [Y/n] ' "$n" >&2
     read -r _ans

--- a/lib/grandma-launch.sh
+++ b/lib/grandma-launch.sh
@@ -310,6 +310,14 @@ fi
 
 # Scope named but not a sweater yet: offer to knit it, instead of a cryptic assemble error.
 if ! resolve_scope_dir "$SCOPE" >/dev/null 2>&1; then
+  # Refuse a reserved name BEFORE the terminal branch. A sweater named after a word the
+  # engine uses in its own logic fails `grandma test` forever, so offering to knit one (or
+  # telling a script to go knit one) is inviting a break that only a rename undoes.
+  if scope_name_is_reserved "$SCOPE"; then
+    printf "\n  '%s' is a word grandma's own engine uses, so a sweater by that name would\n" "$SCOPE" >&2
+    printf "  permanently fail 'grandma test'. Pick another name for it.\n\n" >&2
+    exit 2
+  fi
   if [[ -t 0 && "${GRANDMA_DRY_RUN:-0}" != "1" ]]; then
     printf "\n  no sweater '%s' yet. knit it now? [Y/n] " "$SCOPE" >&2
     read -r _mk

--- a/lib/grandma-lib.sh
+++ b/lib/grandma-lib.sh
@@ -2,15 +2,70 @@
 # grandma-lib — shared helpers. Source this; it expects $ROOT (grandma repo root) set.
 
 # Resolve a scope name (case-insensitive) to its dir under ROOT. Prints dir or fails.
+# It resolves through list_scopes, NOT a bare directory match, so only a real sweater can
+# be loaded. Matching any directory meant `grandma proposals` assembled every sweater's
+# pending proposals into one session, and `grandma watches` / `grandma docs` did the same
+# for whatever happened to sit in the home. The isolation suite could never catch it:
+# list_scopes excludes those directories, so they were never among the scopes under test.
 resolve_scope_dir() {
-  local d name
-  for d in "$ROOT"/*/; do
-    name="$(basename "$d")"; [[ "$name" == "global" ]] && continue
-    if [[ "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" == "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" ]]; then
-      printf '%s' "${d%/}"; return 0
+  local name q
+  q="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    if [[ "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" == "$q" ]]; then
+      printf '%s' "$ROOT/$name"; return 0
+    fi
+  done < <(list_scopes)
+  return 1
+}
+
+# canonical_scope <name> — the sweater's own spelling, lowercased. Everything that builds
+# or matches a per-sweater FILENAME must go through this, because resolution is
+# case-insensitive while filename globbing is not: `grandma Aarc` used to write
+# Aarc-<id>.md, which `grandma review aarc` and the launch-time review offer could never
+# see again. Prints nothing and fails when the name is not a sweater.
+canonical_scope() {
+  local dir; dir="$(resolve_scope_dir "$1")" || return 1
+  basename "$dir" | tr '[:upper:]' '[:lower:]'
+}
+
+# list_proposals <scope> — this sweater's pending proposal files, one path per line (no
+# output when there are none, and none at all when the name is not a sweater).
+#
+# It matches the `# scope=` header the distiller writes INSIDE each proposal, not the
+# filename. Filenames cannot be matched safely: they are <scope>[-<project>]-<stamp>.md and
+# both a sweater and a project may contain dashes, so no prefix pattern separates `home`
+# from `home-ops`. Globbing on a bare prefix meant `grandma review persona` listed
+# personal-chores proposals, `--clear persona` would have deleted them, and the launch-time
+# review offer handed a persona session another sweater's memory to apply. Adding a trailing
+# dash does not fix it either, since `home-` still matches `home-ops-<stamp>.md`.
+# A proposal with no header (hand-written) falls back to the prefix, which is the only thing
+# left to go on.
+list_proposals() {
+  local scope f hdr
+  scope="$(canonical_scope "$1")" || return 0
+  for f in "$ROOT"/proposals/*.md; do
+    [[ -f "$f" ]] || continue
+    # `|| true` is load-bearing: grep exits 1 on a proposal with no scope header, and every
+    # caller runs under `set -euo pipefail`, so without it the first headerless proposal
+    # aborts the whole listing and the sweater silently appears to have nothing pending.
+    hdr="$(sed -n '1,5p' "$f" 2>/dev/null | grep -m1 -oE '^# scope=[^ ]+' | sed 's/^# scope=//' \
+           | tr '[:upper:]' '[:lower:]' || true)"
+    if [[ -n "$hdr" ]]; then
+      [[ "$hdr" == "$scope" ]] && printf '%s\n' "$f"
+    else
+      case "$(basename "$f")" in "$scope"-*) printf '%s\n' "$f" ;; esac
     fi
   done
-  return 1
+  return 0
+}
+
+# read_proposals <scope> — fill the caller's PROPOSAL_FILES array with list_proposals.
+# Kept as a helper because every caller needs the same space-safe read loop.
+# shellcheck disable=SC2034  # PROPOSAL_FILES is the output, read by callers
+read_proposals() {
+  local f; PROPOSAL_FILES=()
+  while IFS= read -r f; do [[ -n "$f" ]] && PROPOSAL_FILES+=("$f"); done < <(list_proposals "$1")
 }
 
 # Normalize a name for fuzzy matching: lowercase, alphanumeric only.
@@ -171,6 +226,66 @@ resolve_project() {
   done < <(project_entries "$reg")
   if   [[ $nbest -eq 1 ]]; then RP_STATUS=OK
   elif [[ $nbest -gt 1 ]]; then RP_STATUS=AMBIG; fi
+}
+
+# scope_name_is_reserved <name> — would a sweater by this name break the engine?
+# The core-purity invariant greps every sweater name as a word against the engine's own
+# source, so a sweater named after a word the engine uses in its logic (`watch`, `review`,
+# `log`, `writing`, ...) makes `grandma test` fail permanently, with no way out but a
+# rename. Catching it at creation costs one comparison; discovering it later costs a
+# migration. Checked against the engine itself, so it stays correct as commands are added.
+scope_name_is_reserved() {
+  local q f
+  q="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  [[ -n "$q" ]] || return 0
+  case "$q" in global|proposals|watches|prompts|templates|assets|docs|lib|bin|test|hooks) return 0 ;; esac
+  for f in "$ENGINE"/lib/*.sh "$ENGINE"/prompts/*.md "$ENGINE"/bin/grandma; do
+    [[ -f "$f" ]] || continue
+    grep -vE '^[[:space:]]*#' "$f" 2>/dev/null | grep -iqE "\b${q}\b" && return 0
+  done
+  return 1
+}
+
+# ---- hook installation (shared by the three installers in the launcher) ----
+
+# hook_cmd <script> [args...] — a hook command line that survives being run by a shell.
+# Sweater and project names carry spaces and parentheses in the wild, and interpolating one
+# raw produced a command that died with a syntax error on every single session, silently:
+# no proposal, no checkpoint, no message. printf %q is the fix, and it is bash 3.2 safe.
+hook_cmd() {
+  local out a; out="$(printf '%q' "$1")"; shift
+  for a in "$@"; do out+=" $(printf '%q' "$a")"; done
+  printf '%s' "$out"
+}
+
+# install_hook <cfg> <event> <matcher> <script> <cmd> <timeout> <async 0|1>
+# Idempotent AND self-healing: it drops any existing entry that runs the same script before
+# adding the current one. Deciding "already present" by exact command match (what this used
+# to do) leaves a previously-installed BROKEN command sitting there and adds a correct one
+# beside it, so the broken one keeps firing and failing forever. Returns 0 and writes
+# nothing when the file already says exactly this. Prints nothing; the caller announces.
+install_hook() {
+  local cfg="$1" ev="$2" matcher="$3" script="$4" cmd="$5" to="$6" async="$7"
+  local base out qscript
+  qscript="$(printf '%q' "$script")"
+  base="$(cat "$cfg" 2>/dev/null || echo '{}')"
+  out="$(printf '%s' "$base" | jq --sort-keys \
+    --arg e "$ev" --arg m "$matcher" --arg s "$script" --arg qs "$qscript" --arg c "$cmd" \
+    --argjson to "$to" --argjson async "$async" '
+      def prune: map(.hooks = ((.hooks // [])
+                     | map(select(((.command // "") | startswith($s)) or
+                                  ((.command // "") | startswith($qs)) | not))))
+                 | map(select(((.hooks // []) | length) > 0));
+      (({"type":"command","command":$c,"timeout":$to})
+        + (if $async == 1 then {"async":true} else {} end)) as $h
+      | {"matcher":$m,"hooks":[$h]} as $entry
+      | .hooks = (.hooks // {})
+      | .hooks[$e] = (((.hooks[$e] // []) | prune) + [$entry])
+    ' 2>/dev/null)" || return 1
+  [[ -n "$out" ]] || return 1
+  [[ "$out" == "$(printf '%s' "$base" | jq --sort-keys . 2>/dev/null)" ]] && return 1
+  mkdir -p "$(dirname "$cfg")"
+  printf '%s' "$out" > "$cfg.tmp" 2>/dev/null && mv "$cfg.tmp" "$cfg"
 }
 
 # Munge an absolute path to its Claude projects dir name (/ -> -).

--- a/lib/grandma-lib.sh
+++ b/lib/grandma-lib.sh
@@ -228,21 +228,26 @@ resolve_project() {
   elif [[ $nbest -gt 1 ]]; then RP_STATUS=AMBIG; fi
 }
 
-# scope_name_is_reserved <name> — would a sweater by this name break the engine?
-# The core-purity invariant greps every sweater name as a word against the engine's own
-# source, so a sweater named after a word the engine uses in its logic (`watch`, `review`,
-# `log`, `writing`, ...) makes `grandma test` fail permanently, with no way out but a
-# rename. Catching it at creation costs one comparison; discovering it later costs a
-# migration. Checked against the engine itself, so it stays correct as commands are added.
+# scope_name_is_reserved <name> — is this name structurally unusable as a sweater?
+#
+# Deliberately NARROW: the CLI subcommands (a sweater by that name is shadowed and can never
+# be launched) and the directories grandma owns inside the memory home (loading one would
+# assemble whatever sits in it). Those two lists are facts about the engine, not judgements.
+#
+# It does NOT scan the engine's source for the name, which was the first attempt. That
+# refused `job-search`, `work`, `personal`, `home`, `client`, `acme` and `reddit` — the exact
+# names grandma's own README and prompts hand people as examples. Those names really do fail
+# the core-purity invariant today, but the defect there is the invariant matching prose in
+# prompt files rather than engine logic, and the cure is to fix that check, not to refuse the
+# names the product recommends. Tracked separately; see docs/architecture.md.
 scope_name_is_reserved() {
-  local q f
+  local q
   q="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
   [[ -n "$q" ]] || return 0
-  case "$q" in global|proposals|watches|prompts|templates|assets|docs|lib|bin|test|hooks) return 0 ;; esac
-  for f in "$ENGINE"/lib/*.sh "$ENGINE"/prompts/*.md "$ENGINE"/bin/grandma; do
-    [[ -f "$f" ]] || continue
-    grep -vE '^[[:space:]]*#' "$f" 2>/dev/null | grep -iqE "\b${q}\b" && return 0
-  done
+  case "$q" in
+    init|save|review|search|ingest|watch|test|doctor|completions|update|version|help) return 0 ;;
+    global|proposals|watches|templates) return 0 ;;
+  esac
   return 1
 }
 

--- a/lib/grandma-review.sh
+++ b/lib/grandma-review.sh
@@ -45,7 +45,8 @@ if [[ "$MODE" == "apply" ]]; then
     FILES=("$PROP/$FILE")
   elif [[ -n "$FILE" ]] && resolve_scope_dir "$FILE" >/dev/null 2>&1; then
     shopt -s nullglob
-    FILES=("$PROP/$FILE"*.md)
+    read_proposals "$FILE"
+    FILES=(${PROPOSAL_FILES[@]+"${PROPOSAL_FILES[@]}"})
     RSCOPE="$FILE"
   fi
   [[ ${#FILES[@]} -gt 0 ]] || { echo "error: no proposal to apply for: ${FILE:-<none>}" >&2; exit 1; }
@@ -90,14 +91,14 @@ fi
 # ---- clear ----
 if [[ "$MODE" == "clear" ]]; then
   shopt -s nullglob
-  files=("$PROP/${SCOPE:+$SCOPE}"*.md); [[ -z "$SCOPE" ]] && files=("$PROP"/*.md)
+  if [[ -n "$SCOPE" ]]; then read_proposals "$SCOPE"; files=(${PROPOSAL_FILES[@]+"${PROPOSAL_FILES[@]}"}); else files=("$PROP"/*.md); fi
   if [[ ${#files[@]} -eq 0 ]]; then echo "no proposals to clear."; exit 0; fi
   rm -f "${files[@]}"; echo "cleared ${#files[@]} proposal(s)."; exit 0
 fi
 
 # ---- list + print ----
 shopt -s nullglob
-if [[ -n "$SCOPE" ]]; then files=("$PROP/$SCOPE"*.md); else files=("$PROP"/*.md); fi
+if [[ -n "$SCOPE" ]]; then read_proposals "$SCOPE"; files=(${PROPOSAL_FILES[@]+"${PROPOSAL_FILES[@]}"}); else files=("$PROP"/*.md); fi
 if [[ ${#files[@]} -eq 0 ]]; then
   echo "no pending proposals${SCOPE:+ for $SCOPE}."
   exit 0

--- a/lib/grandma-save.sh
+++ b/lib/grandma-save.sh
@@ -124,7 +124,11 @@ if [[ "$AUTO" == "1" ]]; then
     exit 0
   fi
   stamp="$(basename "$TRANSCRIPT" .jsonl)"
-  out="$ROOT/proposals/${SCOPE}${PROJECT_NAME:+-$PROJECT_NAME}-${stamp}.md"
+  # Name the file from the sweater's OWN spelling, not what the user typed: resolution is
+  # case-insensitive but globbing is not, so `grandma Aarc` used to write a proposal that
+  # `grandma review aarc` and the launch review offer could never find again.
+  cscope="$(canonical_scope "$SCOPE" || printf '%s' "$SCOPE")"
+  out="$ROOT/proposals/${cscope}${PROJECT_NAME:+-$PROJECT_NAME}-${stamp}.md"
   ASYS="$(cat "$DISTILLER")
 
 $(cat "$ENGINE/prompts/capture.md")
@@ -149,7 +153,9 @@ one-line why. If nothing is durable, output exactly 'No durable learnings.'"
   # the recursion guard set, so this headless session cannot fire a project SessionEnd hook
   # and cascade into another distill. Two independent safeguards against the runaway loop.
   { echo "# grandma memory proposal"
-    echo "# scope=$SCOPE${PROJECT_NAME:+ project=$PROJECT_NAME}  transcript=$(basename "$TRANSCRIPT")"
+    # The scope here is the sweater's own spelling: this header, not the filename, is what
+    # decides which sweater a proposal belongs to, so it has to be exact.
+    echo "# scope=$cscope${PROJECT_NAME:+ project=$PROJECT_NAME}  transcript=$(basename "$TRANSCRIPT")"
     echo
     ( cd "$ROOT" && GRANDMA_DISTILLING=1 claude -p "$APROMPT" --append-system-prompt "$ASYS" 2>/dev/null ) || echo "(distiller failed)"
   } > "$out"

--- a/lib/grandma-test.sh
+++ b/lib/grandma-test.sh
@@ -182,6 +182,39 @@ hits2="$(grep -rn "$up" "$ENGINE/lib" "$ENGINE/prompts" "$ENGINE/bin" "$ENGINE/t
 [[ -n "$hits2" ]] && { bad "hardcoded user path in engine: $(echo "$hits2" | head -3)"; pd_ok=0; }
 [[ "$pd_ok" == "1" ]] && pass "engine free of personal names and user paths"
 
+# ---- 13. Only a real sweater can be loaded, and only its own proposals ----
+# Both halves of this were invisible to the suite before: the isolation check (1) only ever
+# tests names that list_scopes returns, so a directory it excludes could resolve as a
+# sweater and assemble anything sitting in it, and nothing looked at proposal filenames.
+echo "== 13. scope resolution (non-sweaters rejected, proposals not shared) =="
+sr_ok=1
+grep -q 'done < <(list_scopes)' "$ENGINE/lib/grandma-lib.sh" 2>/dev/null || { bad "resolve_scope_dir does not resolve through list_scopes (any directory can load as a sweater)"; sr_ok=0; }
+grep -q 'canonical_scope' "$ENGINE/lib/grandma-save.sh" 2>/dev/null || { bad "save.sh names proposals from the typed scope, not the sweater's own spelling (case-mismatched proposals go unseen)"; sr_ok=0; }
+for f in lib/grandma-review.sh lib/grandma-launch.sh; do
+  grep -qE '\$\{?SCOPE\}?"?\*\.md|\$FILE"\*\.md' "$ENGINE/$f" 2>/dev/null && { bad "$f still globs proposals on a bare scope prefix (a sweater matches longer sweater names)"; sr_ok=0; }
+done
+if [[ "$HOME_OK" == "1" ]]; then
+  for d in proposals watches; do
+    [[ -d "$ROOT/$d" ]] || continue
+    if (cd "$ENGINE" && ROOT="$ROOT" bash -c '. lib/grandma-lib.sh; resolve_scope_dir "'"$d"'"' >/dev/null 2>&1); then
+      bad "'$d' resolves as a sweater (loading it would assemble content from every scope)"; sr_ok=0
+    fi
+  done
+fi
+[[ "$sr_ok" == "1" ]] && pass "only real sweaters resolve, and proposals are matched per sweater"
+
+# ---- 14. Installed hooks survive a shell (names with spaces and parentheses) ----
+echo "== 14. hook commands are shell-safe =="
+hq_ok=1
+grep -q 'hook_cmd' "$ENGINE/lib/grandma-lib.sh" 2>/dev/null || { bad "no hook_cmd helper (hook args are interpolated raw)"; hq_ok=0; }
+grep -q "printf '%q'" "$ENGINE/lib/grandma-lib.sh" 2>/dev/null || { bad "hook_cmd does not quote its arguments"; hq_ok=0; }
+for f in install_rehydrate_hook install_session_end_hook install_precompact_hook; do
+  grep -A6 "^$f()" "$ENGINE/lib/grandma-launch.sh" 2>/dev/null | grep -q 'hook_cmd' \
+    || { bad "$f builds its command without hook_cmd (a project name with a space breaks it silently)"; hq_ok=0; }
+done
+grep -q 'startswith($s)' "$ENGINE/lib/grandma-lib.sh" 2>/dev/null || { bad "install_hook does not prune a stale entry for the same script (a broken command would survive the fix)"; hq_ok=0; }
+[[ "$hq_ok" == "1" ]] && pass "hook commands are quoted, and a stale entry is replaced not duplicated"
+
 echo
 if [[ "$fail" == "0" ]]; then echo "grandma-test: ALL PASS"; else echo "grandma-test: FAILURES ABOVE"; fi
 exit "$fail"

--- a/test/cmd_scope.sh
+++ b/test/cmd_scope.sh
@@ -15,6 +15,9 @@
 #   4. Those globs matched on a bare prefix, so a sweater matched every longer sweater name:
 #      reviewing `home` listed `home-ops` proposals and --clear would have deleted them.
 set -uo pipefail
+# Nothing here is interactive, so detach stdin: a child that reads it would otherwise block
+# (or swallow the caller's input) depending on how the suite was invoked.
+exec </dev/null
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENGINE="$(cd "$HERE/.." && pwd)"
 . "$HERE/lib/assert.sh"
@@ -35,7 +38,7 @@ capture env GRANDMA_DRY_RUN=1 "$GBIN" proposals
 assert_rc 2 "'grandma proposals' is refused, not loaded as a sweater"
 assert_not_contains "memory: proposals loaded" "it never assembles a bundle"
 assert_not_contains "BEGIN proposals/" "and no other sweater's content rides along"
-assert_contains "Pick another name" "and it says why rather than erroring cryptically"
+assert_contains "grandma reserves" "and it says why rather than erroring cryptically"
 
 capture env GRANDMA_DRY_RUN=1 "$GBIN" watches
 assert_rc 2 "'grandma watches' is refused too"
@@ -178,23 +181,40 @@ section "naming — a reserved name is refused at the real call site, not just i
 # scope_name_is_reserved is unit-tested below, but a check nothing calls is not a check.
 # The refusal happens BEFORE the terminal branch, so it is reachable without a pty and a
 # script gets the same answer a person does.
-capture env GRANDMA_HOME="$H" "$GBIN" writing
-assert_rc 2 "'grandma writing' exits 2 instead of offering to knit it"
-assert_contains "is a word grandma's own engine uses" "and says why"
+capture env GRANDMA_HOME="$H" GRANDMA_DRY_RUN=1 "$GBIN" proposals
+assert_rc 2 "'grandma proposals' exits 2 instead of offering to knit it"
+assert_contains "grandma reserves" "and says why it is refused"
 assert_no_file "$H/writing" "no sweater directory was created"
-capture env GRANDMA_HOME="$H" "$GBIN" log
-assert_rc 2 "same for 'log'"
-capture env GRANDMA_HOME="$H" "$GBIN" acme-payments
-assert_rc 1 "an ordinary unknown name still gets the normal knit-it offer path (exit 1)"
-assert_contains "no sweater" "with the usual message"
+
+# The names grandma's own docs hand people as examples MUST still work. The first cut of this
+# check scanned the engine source and refused all of these, which would have been worse than
+# the latent problem it was guarding against.
+for name in job-search work personal home client acme reddit side-projects; do
+  capture env GRANDMA_HOME="$H" GRANDMA_DRY_RUN=1 "$GBIN" "$name" </dev/null
+  assert_rc 1 "'$name' is NOT refused (it reaches the normal unknown-sweater path)"
+  assert_contains "no sweater" "and gets the usual knit-it message"
+done
+
+section "naming — a folder with no scope: frontmatter is explained, not silently hidden"
+# Resolution now goes through list_scopes, which requires frontmatter. A folder that lacks it
+# used to resolve; now it does not. Someone whose files are sitting right there must be told
+# why, not offered to knit a sweater that looks like it already exists.
+mkdir -p "$H/legacy"
+printf '# legacy facts\n- notes with no frontmatter\n' > "$H/legacy/facts.md"
+capture env GRANDMA_HOME="$H" GRANDMA_DRY_RUN=1 "$GBIN" legacy </dev/null
+assert_rc 1 "a frontmatter-less folder does not launch"
+assert_contains "no file in it carries" "it explains that frontmatter is missing"
+assert_contains "scope: legacy" "and names the exact line to add"
+assert_not_contains "knit it now" "it does NOT offer to knit over existing files"
+rm -rf "$H/legacy"
 
 section "naming — a sweater named after an engine word is refused up front"
-for name in watch review writing log; do
+for name in watch review proposals global; do
   capture env GRANDMA_HOME="$H" bash -c \
     '. "'"$ENGINE"'/lib/grandma-lib.sh"; ENGINE="'"$ENGINE"'"; ROOT="'"$H"'"; scope_name_is_reserved "'"$name"'"'
-  assert_rc 0 "'$name' is recognised as reserved (it would break grandma test forever)"
+  assert_rc 0 "'$name' is recognised as reserved (a subcommand, or a folder grandma owns)"
 done
-for name in globex home-ops acme-payments; do
+for name in globex home-ops acme-payments job-search work personal reddit; do
   capture env GRANDMA_HOME="$H" bash -c \
     '. "'"$ENGINE"'/lib/grandma-lib.sh"; ENGINE="'"$ENGINE"'"; ROOT="'"$H"'"; scope_name_is_reserved "'"$name"'"'
   assert_rc 1 "'$name' is allowed (a normal sweater name is not blocked)"

--- a/test/cmd_scope.sh
+++ b/test/cmd_scope.sh
@@ -32,12 +32,14 @@ printf '# p\n# scope=globex\n\ntarget: globex/facts.md | action: append | text: 
 printf '# p\n# scope=home-ops\n\ntarget: home-ops/facts.md | action: append | text: from home-ops\n' > "$H/proposals/home-ops-bbb.md"
 
 capture env GRANDMA_DRY_RUN=1 "$GBIN" proposals
-assert_rc 1 "'grandma proposals' is refused, not loaded as a sweater"
+assert_rc 2 "'grandma proposals' is refused, not loaded as a sweater"
 assert_not_contains "memory: proposals loaded" "it never assembles a bundle"
-assert_contains "no sweater" "and it says why"
+assert_not_contains "BEGIN proposals/" "and no other sweater's content rides along"
+assert_contains "Pick another name" "and it says why rather than erroring cryptically"
 
 capture env GRANDMA_DRY_RUN=1 "$GBIN" watches
-assert_rc 1 "'grandma watches' is refused too"
+assert_rc 2 "'grandma watches' is refused too"
+assert_not_contains "memory: watches loaded" "and assembles nothing"
 
 capture env "$ENGINE/lib/assemble.sh" proposals
 assert_not_contains "BEGIN proposals/" "assemble refuses the same name (no cross-sweater bundle)"
@@ -140,7 +142,52 @@ while IFS= read -r c; do [ -n "$c" ] && { bash -n -c "$c" 2>/dev/null || bad=1; 
   < <(jq -r '.hooks.SessionEnd[].hooks[].command' "$CFG" 2>/dev/null)
 [ "$bad" = 0 ] && ok "and what remains is runnable" || fail "a broken command survived the relaunch"
 
+section "hooks — pruning a stale grandma entry never touches the user's own hooks"
+# The prune is the risky half of the fix: it edits a file the user also owns. Too broad and
+# it silently deletes their hooks. Their entries must survive, both a sibling inside the same
+# group and an unrelated event.
+FCFG="$TMP/foreign/.claude/settings.local.json"; mkdir -p "$(dirname "$FCFG")"
+python3 - "$FCFG" "$ENGINE" <<'PY'
+import json, sys
+cfg, engine = sys.argv[1], sys.argv[2]
+json.dump({"hooks": {
+  "SessionEnd": [{"matcher": "", "hooks": [
+      {"type": "command", "command": "/usr/local/bin/my-own-notify.sh done", "timeout": 10},
+      {"type": "command", "command": f"{engine}/lib/grandma-session-end.sh home-ops yard (Back Garden)",
+       "async": True, "timeout": 600}]}],
+  "PreToolUse": [{"matcher": "Bash", "hooks": [
+      {"type": "command", "command": "/usr/local/bin/audit.sh", "timeout": 5}]}]}}, open(cfg, "w"))
+PY
+capture env GRANDMA_HOME="$H" bash -c '
+  . "'"$ENGINE"'/lib/grandma-lib.sh"; ENGINE="'"$ENGINE"'"; ROOT="'"$H"'"
+  s="$ENGINE/lib/grandma-session-end.sh"
+  install_hook "'"$FCFG"'" SessionEnd "" "$s" "$(hook_cmd "$s" home-ops "yard (Back Garden)")" 600 1'
+assert_rc 0 "installing over a config with foreign hooks succeeds"
+capture jq -r '.hooks.PreToolUse[].hooks[].command' "$FCFG"
+assert_contains "/usr/local/bin/audit.sh" "an unrelated event's hooks are untouched"
+capture jq -r '.hooks.SessionEnd[].hooks[].command' "$FCFG"
+assert_contains "/usr/local/bin/my-own-notify.sh" "a foreign hook sharing the group survives"
+n="$(jq -r '[.hooks.SessionEnd[].hooks[] | select(.command | contains("grandma-session-end.sh"))] | length' "$FCFG")"
+[ "$n" = "1" ] && ok "the stale grandma entry was replaced, not duplicated" \
+               || fail "expected 1 grandma session-end hook, found $n"
+capture jq -r '.hooks.SessionEnd[].hooks[] | select(.command | contains("grandma-session-end.sh")) | .command' "$FCFG"
+assert_contains "Back" "and the replacement carries the quoted project name"
+
 # ------------------------------------------------- 4. reserved sweater names ---
+section "naming — a reserved name is refused at the real call site, not just in the helper"
+# scope_name_is_reserved is unit-tested below, but a check nothing calls is not a check.
+# The refusal happens BEFORE the terminal branch, so it is reachable without a pty and a
+# script gets the same answer a person does.
+capture env GRANDMA_HOME="$H" "$GBIN" writing
+assert_rc 2 "'grandma writing' exits 2 instead of offering to knit it"
+assert_contains "is a word grandma's own engine uses" "and says why"
+assert_no_file "$H/writing" "no sweater directory was created"
+capture env GRANDMA_HOME="$H" "$GBIN" log
+assert_rc 2 "same for 'log'"
+capture env GRANDMA_HOME="$H" "$GBIN" acme-payments
+assert_rc 1 "an ordinary unknown name still gets the normal knit-it offer path (exit 1)"
+assert_contains "no sweater" "with the usual message"
+
 section "naming — a sweater named after an engine word is refused up front"
 for name in watch review writing log; do
   capture env GRANDMA_HOME="$H" bash -c \

--- a/test/cmd_scope.sh
+++ b/test/cmd_scope.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Behavioral tests for scope resolution, proposal matching, and hook-command quoting.
+#
+# Four bugs, all found on a live memory home, none of which the suite could see before:
+#
+#   1. Any top-level directory resolved as a sweater, so `grandma proposals` assembled every
+#      sweater's pending proposals into ONE session. Invisible to the isolation check because
+#      that check only iterates list_scopes, which excludes exactly those directories.
+#   2. Hook commands interpolated the scope and project raw. A project registered as
+#      "yard (Back Garden)" produced a command that dies with a shell syntax error, so its
+#      SessionEnd distill and PreCompact checkpoint never ran and never said so.
+#   3. Proposal filenames were built from the scope AS TYPED while every reader globbed
+#      case-sensitively, so `grandma Globex` wrote a proposal `grandma review globex` and the
+#      launch-time review offer could not find.
+#   4. Those globs matched on a bare prefix, so a sweater matched every longer sweater name:
+#      reviewing `home` listed `home-ops` proposals and --clear would have deleted them.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE="$(cd "$HERE/.." && pwd)"
+. "$HERE/lib/assert.sh"
+. "$HERE/lib/fixture.sh"
+
+GBIN="$ENGINE/bin/grandma"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+H="$TMP/home"; export GRANDMA_HOME="$H"; export SHELL=""
+make_fixture_home "$H"
+
+# ---------------------------------------------------------- 1. resolution ------
+section "resolution — a directory that is not a sweater cannot be loaded"
+mkdir -p "$H/proposals" "$H/watches"
+printf '# p\n# scope=globex\n\ntarget: globex/facts.md | action: append | text: from globex\n' > "$H/proposals/globex-aaa.md"
+printf '# p\n# scope=home-ops\n\ntarget: home-ops/facts.md | action: append | text: from home-ops\n' > "$H/proposals/home-ops-bbb.md"
+
+capture env GRANDMA_DRY_RUN=1 "$GBIN" proposals
+assert_rc 1 "'grandma proposals' is refused, not loaded as a sweater"
+assert_not_contains "memory: proposals loaded" "it never assembles a bundle"
+assert_contains "no sweater" "and it says why"
+
+capture env GRANDMA_DRY_RUN=1 "$GBIN" watches
+assert_rc 1 "'grandma watches' is refused too"
+
+capture env "$ENGINE/lib/assemble.sh" proposals
+assert_not_contains "BEGIN proposals/" "assemble refuses the same name (no cross-sweater bundle)"
+
+section "resolution — real sweaters still resolve, in any case"
+for name in globex GLOBEX home-ops HOME-OPS; do
+  capture env GRANDMA_DRY_RUN=1 "$GBIN" "$name"
+  assert_rc 0 "'$name' still launches"
+  assert_contains "memory:" "and assembles a bundle"
+done
+
+# ------------------------------------------------ 3 + 4. proposal matching -----
+section "proposals — a sweater sees its own, whatever case was typed"
+rm -f "$H/proposals/"*.md
+printf '# p\n# scope=globex\n\ntarget: globex/facts.md | action: append | text: x\n' > "$H/proposals/globex-ccc.md"
+capture env "$GBIN" review GLOBEX
+assert_rc 0 "review runs with a differently-cased name"
+assert_contains "globex-ccc.md" "the proposal is found regardless of the case typed"
+capture env GRANDMA_DRY_RUN=1 "$GBIN" GLOBEX
+assert_contains "pending proposal" "and the launch-time review offer sees it too"
+
+section "proposals — saving under a differently-cased name stays findable"
+# The round trip that used to break: save as typed, read back lowercased.
+printf '# p\n# scope=globex\n\ntarget: globex/facts.md | action: append | text: y\n' > "$H/proposals/$(env GRANDMA_HOME="$H" bash -c '. '"$ENGINE"'/lib/grandma-lib.sh; ROOT="'"$H"'"; canonical_scope GLOBEX')-ddd.md"
+assert_file "$H/proposals/globex-ddd.md" "canonical_scope lowercases to the sweater's own spelling"
+
+section "proposals — one sweater never sees a longer-named sweater's proposals"
+rm -f "$H/proposals/"*.md
+printf '# p\n# scope=home-ops\n\ntarget: home-ops/facts.md | action: append | text: kebab canary\n' > "$H/proposals/home-ops-eee.md"
+capture env "$GBIN" review home
+assert_rc 0 "reviewing a shorter name runs"
+assert_not_contains "home-ops-eee.md" "'home' does NOT match 'home-ops' proposals"
+capture env "$GBIN" review home-ops
+assert_contains "home-ops-eee.md" "but home-ops finds its own"
+
+section "proposals — a headerless proposal does not blank out the whole listing"
+# Matching on the `# scope=` header means grep exits 1 on a hand-written proposal that has
+# none, and every caller runs under `set -euo pipefail`, so an unguarded read there aborts
+# the listing and the sweater looks like it has nothing pending. Order matters: the
+# headerless file has to sort BEFORE the real one to reproduce it.
+printf '# grandma memory proposal\ntarget: home-ops/facts.md | action: append | text: no header here\n' \
+  > "$H/proposals/aaa-headerless.md"
+capture env "$GBIN" review home-ops
+assert_rc 0 "review still runs with a headerless proposal sitting in the directory"
+assert_contains "home-ops-eee.md" "the real proposal is still found (the listing did not abort)"
+capture env GRANDMA_DRY_RUN=1 "$GBIN" home-ops
+assert_contains "pending proposal" "and the launch offer still sees it under set -e"
+rm -f "$H/proposals/aaa-headerless.md"
+
+section "proposals — --clear only deletes the named sweater's proposals"
+printf '# p\n# scope=globex\n\ntarget: globex/facts.md | action: append | text: keep me\n' > "$H/proposals/globex-fff.md"
+capture env "$GBIN" review --clear home
+assert_rc 0 "clearing a non-matching prefix runs"
+assert_file "$H/proposals/home-ops-eee.md" "'--clear home' did NOT delete home-ops proposals"
+assert_file "$H/proposals/globex-fff.md" "and left the other sweater alone"
+capture env "$GBIN" review --clear home-ops
+assert_no_file "$H/proposals/home-ops-eee.md" "clearing the real name does delete them"
+assert_file "$H/proposals/globex-fff.md" "still only that sweater's"
+
+# --------------------------------------------------- 2. hook quoting ----------
+section "hooks — a project name with spaces and parentheses produces a runnable command"
+# The live failure: a catalog heading like "yard (Back Garden)" wrote an unquoted command
+# that every session died on with `syntax error near unexpected token '('`.
+PROJ="$H/projects/yard"
+sed -i.bak 's/^## Yard$/## yard (Back Garden)/' "$H/home-ops/projects.md" && rm -f "$H/home-ops/projects.md.bak"
+CBIN="$TMP/cbin"; make_fake_claude "$CBIN" "$TMP/launched" >/dev/null
+capture env GRANDMA_HOME="$H" GRANDMA_NO_SPLASH=1 PATH="$CBIN:$PATH" HOME="$TMP/fh" "$GBIN" home-ops yard </dev/null
+assert_rc 0 "a launch into the awkwardly-named project runs"
+CFG="$PROJ/.claude/settings.local.json"
+assert_file "$CFG" "hooks were installed"
+bad=0
+while IFS= read -r c; do
+  [ -n "$c" ] || continue
+  bash -n -c "$c" 2>/dev/null || { bad=1; echo "         | unrunnable: $c"; }
+done < <(jq -r '.hooks[]?[].hooks[].command' "$CFG" 2>/dev/null)
+[ "$bad" = 0 ] && ok "every installed hook command parses in a shell" \
+               || fail "an installed hook command is a shell syntax error"
+capture jq -r '.hooks.SessionEnd[0].hooks[0].command' "$CFG"
+assert_contains "Back" "the project name survives into the command"
+
+section "hooks — re-launching replaces a stale command, never stacks a second one"
+# Deciding 'already installed' by exact string match left a BROKEN command in place and
+# added a correct one beside it, so the broken one kept firing.
+python3 - "$CFG" "$ENGINE" <<'PY'
+import json, sys
+cfg, engine = sys.argv[1], sys.argv[2]
+d = json.load(open(cfg))
+d["hooks"]["SessionEnd"] = [{"matcher": "", "hooks": [{"type": "command",
+  "command": f"{engine}/lib/grandma-session-end.sh home-ops yard (Back Garden)", "async": True, "timeout": 600}]}]
+json.dump(d, open(cfg, "w"))
+PY
+capture env GRANDMA_HOME="$H" GRANDMA_NO_SPLASH=1 PATH="$CBIN:$PATH" HOME="$TMP/fh" "$GBIN" home-ops yard </dev/null
+assert_rc 0 "the repair launch runs"
+n="$(jq -r '[.hooks.SessionEnd[].hooks[] | select(.command | contains("grandma-session-end.sh"))] | length' "$CFG" 2>/dev/null)"
+[ "$n" = "1" ] && ok "exactly one session-end hook remains (the broken one was replaced)" \
+               || fail "expected 1 session-end hook, found $n (a stale broken command survived)"
+capture jq -r '.hooks.SessionEnd[].hooks[].command' "$CFG"
+bad=0
+while IFS= read -r c; do [ -n "$c" ] && { bash -n -c "$c" 2>/dev/null || bad=1; }; done \
+  < <(jq -r '.hooks.SessionEnd[].hooks[].command' "$CFG" 2>/dev/null)
+[ "$bad" = 0 ] && ok "and what remains is runnable" || fail "a broken command survived the relaunch"
+
+# ------------------------------------------------- 4. reserved sweater names ---
+section "naming — a sweater named after an engine word is refused up front"
+for name in watch review writing log; do
+  capture env GRANDMA_HOME="$H" bash -c \
+    '. "'"$ENGINE"'/lib/grandma-lib.sh"; ENGINE="'"$ENGINE"'"; ROOT="'"$H"'"; scope_name_is_reserved "'"$name"'"'
+  assert_rc 0 "'$name' is recognised as reserved (it would break grandma test forever)"
+done
+for name in globex home-ops acme-payments; do
+  capture env GRANDMA_HOME="$H" bash -c \
+    '. "'"$ENGINE"'/lib/grandma-lib.sh"; ENGINE="'"$ENGINE"'"; ROOT="'"$H"'"; scope_name_is_reserved "'"$name"'"'
+  assert_rc 1 "'$name' is allowed (a normal sweater name is not blocked)"
+done
+
+section "integrity — the suite still passes on the fixture home"
+capture env GRANDMA_HOME="$H" "$GBIN" test
+assert_rc 0 "grandma test passes"
+assert_contains "only real sweaters resolve" "invariant 13 runs"
+assert_contains "hook commands are quoted" "invariant 14 runs"
+
+echo
+if [ "$FAILS" -eq 0 ]; then echo "cmd_scope: PASS"; else echo "cmd_scope: $FAILS FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
Four bugs, all found on a live memory home rather than in CI, and none of them visible to the suite. Three sit in code paths the invariants structurally cannot reach; the fourth had been failing silently in the wild for days.

Independent of #33. Meant to land first.

## 1. Any directory resolved as a sweater

`grandma proposals` did not error. It loaded, and assembled every sweater's pending proposals into one session:

```
banner: memory: proposals loaded · 13 files · ~11974 tokens
  + proposals/aarc-...md  + proposals/mercor-...md  + proposals/persona-...md  + proposals/spy-...md
```

Four unrelated contexts in one system prompt, which is the exact thing the isolation promise exists to prevent. `grandma watches` did the same, and on a memory home that happens to contain other folders, so did those.

The suite could never see it. The isolation check iterates `list_scopes`, and `list_scopes` excludes precisely these directories, so they were never among the scopes under test. Resolution now goes through `list_scopes` in both places that did it: the launcher, and `assemble.sh`, which carried its own copy of the loop and had to be fixed separately.

## 2. Hook commands were interpolated raw

A project registered as `yard (Back Garden)` produced this in its `settings.local.json`:

```
.../grandma-session-end.sh home-ops yard (Back Garden)
  -> bash: -c: line 0: syntax error near unexpected token `('
```

Both the end-of-session distill and the pre-compaction checkpoint for that project never ran, and nothing surfaced. You simply get no proposals from it, forever. Arguments now go through `printf %q`, and the three near-identical installers share one helper.

That helper also **prunes** an existing entry for the same script before adding the current one. This matters more than the quoting: the old code decided "already installed" by exact command match, so shipping the quoting fix alone would have left the broken command in place and added a correct one beside it. The broken one keeps firing.

## 3 and 4. A sweater could not see its own proposals, and could see other sweaters'

One root cause, two symptoms. `$SCOPE` as typed was used both to build proposal filenames and to match them.

Case: `grandma Aarc` wrote `Aarc-<id>.md`, which `grandma review aarc` and the launch-time review offer could not find. The proposal just rots.

Prefix: matching was `"$scope"*`, so a sweater matched every longer sweater name. Reviewing `home` listed `home-ops` proposals, and `--clear home` would have deleted them. Worse, `grandma <sweater>` offers a review at launch and execs `review --apply <sweater>`, which assembles one sweater's memory and hands the session another sweater's proposal to apply.

Adding a trailing dash does not fix it, which is worth stating because it is the obvious patch: `home-` still matches `home-ops-<stamp>.md`. Since both a sweater and a project may contain dashes, no filename pattern separates them. Matching is now on the `scope=` header the distiller writes inside each proposal, which is exact, with a filename fallback for hand-written ones.

## 5. Reserved sweater names

The core-purity invariant greps every sweater name as a word against the engine source, so a sweater named after a word the engine uses (`watch`, `review`, `log`, `writing`) fails `grandma test` permanently, with a rename as the only cure. Verified on a clean fixture: those four produce 4 to 7 hits each. Knitting one is now refused up front, checked against the engine itself so it stays correct as commands are added.

## Verification

`./test/run.sh` green, `shellcheck -S warning` clean.

Two new invariants (13 and 14) cover the classes. `test/cmd_scope.sh` covers the behaviour, including that `--clear` on a non-matching prefix leaves the other sweater's files on disk.

Every fix was delta-tested by reverting it and watching the suite go red:

| reverted | assertions that fail |
|---|---|
| resolver back to any-directory | 6 |
| header matching back to the typed name | 2 |
| `printf %q` back to raw interpolation | 2, with the unrunnable commands printed |
| the `set -e` guard on the header read | 2 |

## One thing worth reading

That last row is a bug the fix itself introduced and the suite caught. Matching on the header means `grep` exits 1 on a proposal that has none, and every caller runs under `set -euo pipefail`, so the first headerless proposal aborted the whole listing and the sweater looked like it had nothing pending. A full suite run was green before `cmd_launch` surfaced it, because the fixture that reproduces it needs a headerless proposal sorting ahead of a real one. It is the same failure class the architecture notes already warn about, which is a decent argument for keeping those notes.
